### PR TITLE
Fix tile sizes and temporary allocation issues in FIR algorithms

### DIFF
--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -23,10 +23,11 @@ module Algorithm
     abstract Alg
     "Filter using the Fast Fourier Transform" immutable FFT <: Alg end
     "Filter using a direct algorithm" immutable FIR <: Alg end
+    "Cache-efficient filtering using tiles" immutable FIRTiled <: Alg end
     "Filter with an Infinite Impulse Response filter" immutable IIR <: Alg end
     "Filter with a cascade of mixed types (IIR, FIR)" immutable Mixed <: Alg end
 end
-using .Algorithm: Alg, FFT, FIR, IIR, Mixed
+using .Algorithm: Alg, FFT, FIR, FIRTiled, IIR, Mixed
 
 Alg{A<:Alg}(r::AbstractResource{A}) = r.settings
 

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -264,7 +264,7 @@ function imfilter!(r::AbstractResource, out::AbstractArray, A::AbstractArray, ke
     # For multiple stages of filtering, we introduce a second buffer
     # and swap them at each stage. The first of the two is the one
     # that holds the most recent result.
-    A2 = similar(A)  # for type-stability, let's hope it's really the *same* type...
+    A2 = similar(A, eltype(out))
     if fillbuf_nan[]
         fill!(A2, NaN)  # for testing purposes
     end

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -328,9 +328,9 @@ end
 function _imfilter_tiled!{AA<:AbstractArray}(r::CPU1, out, A, kernel::Tuple{Any,Any}, border::NoPad, tiles::Vector{AA}, indsout)
     k1, k2 = kernel
     tile = tiles[1]
-    indsk1, indstile = indices(k1), indices(tile)
+    indsk2, indstile = indices(k2), indices(tile)
     sz = map(length, indstile)
-    chunksz = map(length, shrink(indstile, indsk1))
+    chunksz = map(length, shrink(indstile, indsk2))
     for tinds in TileIterator(indsout, chunksz)
         tileinds = expand(tinds, k2)
         tileb = TileBuffer(tile, tileinds)
@@ -344,9 +344,9 @@ end
 function _imfilter_tiled!{AA<:AbstractArray}(r::CPUThreads, out, A, kernel::Tuple{Any,Any}, border::NoPad, tiles::Vector{AA}, indsout)
     k1, k2 = kernel
     tile = tiles[1]
-    indsk1, indstile = indices(k1), indices(tile)
+    indsk2, indstile = indices(k2), indices(tile)
     sz = map(length, indstile)
-    chunksz = map(length, shrink(indstile, indsk1))
+    chunksz = map(length, shrink(indstile, indsk2))
     tileinds_all = collect(expand(inds, k2) for inds in TileIterator(indsout, chunksz))
     _imfilter_tiled_threads!(CPU1(r), out, A, samedims(out, k1), samedims(out, k2), border, tileinds_all, tiles)
 end
@@ -366,9 +366,9 @@ end
 function _imfilter_tiled!{AA<:AbstractArray}(r::CPU1, out, A, kernel::Tuple{Any,Any,Vararg{Any}}, border::NoPad, tiles::Vector{Tuple{AA,AA}}, indsout)
     k1, kt = kernel[1], tail(kernel)
     tilepair = tiles[1]
-    indsk1, indstile = indices(k1), indices(tilepair[1])
+    indstile = indices(tilepair[1])
     sz = map(length, indstile)
-    chunksz = map(length, shrink(indstile, indsk1))
+    chunksz = map(length, shrink(indstile, kt))
     for tinds in TileIterator(indsout, chunksz)
         tileinds = expand(tinds, kt)
         tileb1 = TileBuffer(tilepair[1], tileinds)
@@ -381,9 +381,9 @@ end
 function _imfilter_tiled!{AA<:AbstractArray}(r::CPUThreads, out, A, kernel::Tuple{Any,Any,Vararg{Any}}, border::NoPad, tiles::Vector{Tuple{AA,AA}}, indsout)
     k1, kt = kernel[1], tail(kernel)
     tilepair = tiles[1]
-    indsk1, indstile = indices(k1), indices(tilepair[1])
+    indstile = indices(tilepair[1])
     sz = map(length, indstile)
-    chunksz = map(length, shrink(indstile, indsk1))
+    chunksz = map(length, shrink(indstile, kt))
     tileinds_all = collect(expand(inds, kt) for inds in TileIterator(indsout, chunksz))
     _imfilter_tiled_threads!(CPU1(r), out, A, samedims(out, k1), kt, border, tileinds_all, tiles)
 end

--- a/test/cascade.jl
+++ b/test/cascade.jl
@@ -1,4 +1,4 @@
-using ImageFiltering, ImageCore, OffsetArrays
+using ImageFiltering, ImageCore, OffsetArrays, ComputationalResources
 using Base.Test
 
 @testset "cascade" begin
@@ -19,7 +19,8 @@ using Base.Test
     kern2 = OffsetArray(c.*c', -2:2, -2:2)
     kern2x = OffsetArray(c.*ones(1,3), -2:2, -1:1)
     kern2y = OffsetArray(ones(3).*c',  -1:1, -2:2)
-    for r in (CPU1(Algorithm.FIR()), CPUThreads(Algorithm.FIR()))
+    for r in (CPU1(Algorithm.FIR()), CPU1(Algorithm.FIRTiled()),
+              CPUThreads(Algorithm.FIR()), CPUThreads(Algorithm.FIRTiled()))
         for border in ("replicate", "circular", "symmetric", "reflect", Fill(zero(eltype(a))))
             afc = imfilter(r, a, (kernx, kerny, kernx, kerny), border)
             af2 = imfilter(r, a, kern2, border)
@@ -36,3 +37,5 @@ using Base.Test
         end
     end
 end
+
+nothing

--- a/test/nd.jl
+++ b/test/nd.jl
@@ -66,7 +66,7 @@ end
     img = trues(10,10,10)
     kernel = centered(trues(3,3,3)/27)
     for border in ("replicate", "circular", "symmetric", "reflect", Fill(true))
-        for alg in (Algorithm.FIR(), Algorithm.FFT())
+        for alg in (Algorithm.FIR(), Algorithm.FIRTiled(), Algorithm.FFT())
             @test imfilter(img, kernel, border) ≈ img
         end
     end


### PR DESCRIPTION
This fixes the bug noted in https://github.com/JuliaImages/ImageFiltering.jl/issues/9#issuecomment-254013441. The inaccuracy noted in the same issue (https://github.com/JuliaImages/ImageFiltering.jl/issues/9#issuecomment-249136104) was presumably fixed in f66e387c0460c18c3010a328e6eab10bba0aaf87, but that fix had a bug that led to the "inadequate" error.

This also introduces `FIRTiled` so it's possible to control explicitly whether the tiled algorithm is used. If nothing else, this is very useful for testing to make sure that all code-paths get exercised.

CC @GunnarFarneback, @tlnagy.