### PR TITLE
Performance enhancements (fixes #9)

### DIFF
--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -24,9 +24,13 @@ module Algorithm
     abstract Alg
     "Filter using the Fast Fourier Transform" immutable FFT <: Alg end
     "Filter using a direct algorithm" immutable FIR <: Alg end
-    "Cache-efficient filtering using tiles" immutable FIRTiled <: Alg end
+    "Cache-efficient filtering using tiles" immutable FIRTiled{N} <: Alg
+        tilesize::Dims{N}
+    end
     "Filter with an Infinite Impulse Response filter" immutable IIR <: Alg end
     "Filter with a cascade of mixed types (IIR, FIR)" immutable Mixed <: Alg end
+
+    FIRTiled() = FIRTiled(())
 end
 using .Algorithm: Alg, FFT, FIR, FIRTiled, IIR, Mixed
 

--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -10,6 +10,7 @@ export Kernel, KernelFactors, Pad, Fill, Inner, NA, NoPad, Algorithm, imfilter, 
 
 typealias FixedColorant{T<:UFixed} Colorant{T}
 typealias StaticOffsetArray{T,N,A<:StaticArray} OffsetArray{T,N,A}
+typealias OffsetVector{T} OffsetArray{T,1}
 
 # Needed for type-stability
 function Base.transpose{T}(A::StaticOffsetArray{T,2})

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -606,36 +606,37 @@ function _imfilter_inbounds!(r::AbstractResource, z, out, A::AbstractArray, k::A
 end
 # end unfortunate specializations
 
-function _imfilter_iter!(r::AbstractResource, out, padded, kernel::AbstractArray, iter)
-    p = padded[first(iter)] * first(kernel)
-    z = zero(typeof(p+p))
-    Rk = CartesianRange(indices(kernel))
-    for I in iter
-        tmp = z
-        for J in Rk
-            @unsafe tmp += padded[I+J]*kernel[J]
-        end
-        out[I] = tmp
-    end
-    out
-end
+## commented out because "virtual padding" is commented out
+# function _imfilter_iter!(r::AbstractResource, out, padded, kernel::AbstractArray, iter)
+#     p = padded[first(iter)] * first(kernel)
+#     z = zero(typeof(p+p))
+#     Rk = CartesianRange(indices(kernel))
+#     for I in iter
+#         tmp = z
+#         for J in Rk
+#             @unsafe tmp += padded[I+J]*kernel[J]
+#         end
+#         out[I] = tmp
+#     end
+#     out
+# end
 
-function _imfilter_iter!(r::AbstractResource, out, padded, kern::ReshapedOneD, iter)
-    Rpre, ind, Rpost = iterdims(indices(out), kern)
-    k = kern.data
-    indsk = indices(k, 1)
-    p = padded[first(iter)] * first(k)
-    TT = typeof(p+p)
-    for I in iter
-        Ipre, i, Ipost = KernelFactors.indexsplit(I, kern)
-        tmp = zero(TT)
-        @unsafe for j in indsk
-            tmp += padded[Ipre,i+j,Ipost]*k[j]
-        end
-        out[I] = tmp
-    end
-    out
-end
+# function _imfilter_iter!(r::AbstractResource, out, padded, kern::ReshapedOneD, iter)
+#     Rpre, ind, Rpost = iterdims(indices(out), kern)
+#     k = kern.data
+#     indsk = indices(k, 1)
+#     p = padded[first(iter)] * first(k)
+#     TT = typeof(p+p)
+#     for I in iter
+#         Ipre, i, Ipost = KernelFactors.indexsplit(I, kern)
+#         tmp = zero(TT)
+#         @unsafe for j in indsk
+#             tmp += padded[Ipre,i+j,Ipost]*k[j]
+#         end
+#         out[I] = tmp
+#     end
+#     out
+# end
 
 
 
@@ -1123,17 +1124,12 @@ safetail(R::CartesianRange) = CartesianRange(CartesianIndex(tail(R.start.I)),
                                              CartesianIndex(tail(R.stop.I)))
 safetail(R::CartesianRange{CartesianIndex{1}}) = CartesianRange(())
 safetail(R::CartesianRange{CartesianIndex{0}}) = CartesianRange(())
-safetail(t::Indices) = tail(t)
-safetail(::Indices{1}) = CartesianRange(())
-safetail(::Tuple{}) = CartesianRange(())
 safetail(I::CartesianIndex) = CartesianIndex(tail(I.I))
 safetail(::CartesianIndex{1}) = CartesianIndex(())
 safetail(::CartesianIndex{0}) = CartesianIndex(())
 
 safehead(R::CartesianRange) = R.start[1]:R.stop[1]
 safehead(R::CartesianRange{CartesianIndex{0}}) = CartesianRange(())
-safehead(t::Indices) = t[1]
-safehead(::Tuple{}) = CartesianRange(())
 safehead(I::CartesianIndex) = I[1]
 safehead(::CartesianIndex{0}) = CartesianIndex(())
 

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -516,6 +516,20 @@ function _imfilter_inbounds!(r::AbstractResource, out, A::AbstractArray, kern::R
     _imfilter_inbounds(r, TT, out, A, k, Rpre, ind, Rpost)
 end
 
+function _imfilter_inbounds{TT}(r::AbstractResource, ::Type{TT}, out, A::AbstractArray, k::AbstractVector, Rpre::CartesianRange{CartesianIndex{0}}, ind, Rpost::CartesianRange)
+    indsk = indices(k, 1)
+    for Ipost in Rpost
+        for i in ind
+            tmp = zero(TT)
+            @unsafe for j in indsk
+                tmp += A[i+j,Ipost]*k[j]
+            end
+            @unsafe out[i,Ipost] = tmp
+        end
+    end
+    out
+end
+
 function _imfilter_inbounds{TT}(r::AbstractResource, ::Type{TT}, out, A::AbstractArray, k::AbstractVector, Rpre::CartesianRange, ind, Rpost::CartesianRange)
     indsk = indices(k, 1)
     for Ipost in Rpost

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -540,32 +540,18 @@ function _imfilter_inbounds!(r::AbstractResource, out, A::AbstractArray, kern::R
         return out
     end
     p = A[first(R)+first(Rk)] * first(k)
-    TT = typeof(p+p)
-    _imfilter_inbounds(r, TT, out, A, k, Rpre, ind, Rpost)
+    z = zero(typeof(p+p))
+    _imfilter_inbounds!(r, z, out, A, k, Rpre, ind, Rpost)
 end
 
-function _imfilter_inbounds{TT}(r::AbstractResource, ::Type{TT}, out, A::AbstractArray, k::AbstractVector, Rpre::CartesianRange{CartesianIndex{0}}, ind, Rpost::CartesianRange)
+function _imfilter_inbounds!(r::AbstractResource, z, out, A::AbstractArray, k::AbstractVector, Rpre::CartesianRange, ind, Rpost::CartesianRange)
     indsk = indices(k, 1)
     for Ipost in Rpost
         for i in ind
-            tmp = zero(TT)
-            @unsafe for j in indsk
-                tmp += A[i+j,Ipost]*k[j]
-            end
-            @unsafe out[i,Ipost] = tmp
-        end
-    end
-    out
-end
-
-function _imfilter_inbounds{TT}(r::AbstractResource, ::Type{TT}, out, A::AbstractArray, k::AbstractVector, Rpre::CartesianRange, ind, Rpost::CartesianRange)
-    indsk = indices(k, 1)
-    for Ipost in Rpost
-        for Ipre in Rpre
-            for i in ind
-                tmp = zero(TT)
-                @unsafe for j in indsk
-                    tmp += A[Ipre,i+j,Ipost]*k[j]
+            for Ipre in Rpre
+                tmp = z
+                for j in indsk
+                    @unsafe tmp += A[Ipre,i+j,Ipost]*k[j]
                 end
                 @unsafe out[Ipre,i,Ipost] = tmp
             end

--- a/src/kernelfactors.jl
+++ b/src/kernelfactors.jl
@@ -135,6 +135,11 @@ end
     indspre, inds[1], tail(inds)   # return the "central" and trailing dimensions
 end
 
+function indexsplit{_,N}(I::CartesianIndex{N}, v::ReshapedOneD{_,N})
+    ipre, i, ipost = _iterdims((), (), I.I, v)
+    CartesianIndex(ipre), i, CartesianIndex(ipost)
+end
+
 #### FIR filters
 
 ## gradients

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -26,8 +26,19 @@ using ImageFiltering, OffsetArrays, Base.Test
     kern = KernelFactors.IIRGaussian(Float64, [1,2.0f0])
     @test isa(kern, Tuple{KernelFactors.ReshapedOneD{Float64},KernelFactors.ReshapedOneD{Float64}})
 
+    @test ndims(Pad(:replicate, (3,3))) == 2
+
     @test KernelFactors.kernelfactors(([0,3], [1,7]))  == (reshape([0,3], 1:2, 0:0), reshape([1,7], 0:0, 1:2))
     @test KernelFactors.kernelfactors(([0,3], [1,7]')) == (reshape([0,3], 2, 1), reshape([1,7], 1, 2))
+
+    tiles = ImageFiltering.tile_allocate(Float32, (rand(3),rand(3)'))
+    @test isa(tiles, Vector{Matrix{Float32}})
+    @test length(tiles) == 1
+
+    @test length(ImageFiltering.safetail(CartesianRange(()))) == 1
+    @test ImageFiltering.safetail(CartesianIndex(())) == CartesianIndex(())
+    @test length(ImageFiltering.safehead(CartesianRange(()))) == 1
+    @test ImageFiltering.safehead(CartesianIndex(())) == CartesianIndex(())
 
     # Warnings
     const OLDERR = STDERR


### PR DESCRIPTION
Using the benchmark of #9 (with a switch to `FIRTiled` for the second one), I now get this:
```
BenchmarkTools.Trial: 
  samples:          115
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  3.88 mb
  allocs estimate:  45
  minimum time:     39.40 ms (0.00% GC)
  median time:      40.57 ms (0.00% GC)
  mean time:        43.80 ms (0.18% GC)
  maximum time:     76.27 ms (0.00% GC)
BenchmarkTools.Trial: 
  samples:          404
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  3.91 mb
  allocs estimate:  533
  minimum time:     11.55 ms (0.00% GC)
  median time:      11.87 ms (0.00% GC)
  mean time:        12.38 ms (0.77% GC)
  maximum time:     23.65 ms (2.71% GC)
BenchmarkTools.Trial: 
  samples:          356
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  15.34 mb
  allocs estimate:  94
  minimum time:     12.66 ms (0.00% GC)
  median time:      13.42 ms (3.70% GC)
  mean time:        14.07 ms (2.44% GC)
  maximum time:     25.55 ms (2.20% GC)
BenchmarkTools.Trial: 
  samples:          99
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  11.56 mb
  allocs estimate:  39
  minimum time:     48.02 ms (0.00% GC)
  median time:      49.08 ms (0.00% GC)
  mean time:        50.55 ms (0.53% GC)
  maximum time:     78.06 ms (0.00% GC)
BenchmarkTools.Trial: 
  samples:          275
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  23.02 mb
  allocs estimate:  78
  minimum time:     17.07 ms (2.95% GC)
  median time:      17.63 ms (2.96% GC)
  mean time:        18.18 ms (2.93% GC)
  maximum time:     35.66 ms (1.85% GC)
```
That means that the separable algorithm runs in 67% of the time (single-threaded), and the dense algorithm runs in 83% of the time.

Closes #9. This is a **significant** uglification of the internal code, unfortunately. It would be nice if julia/LLVM did all of this automatically. That might come with `@polly` support.