### PR TITLE
Implement a generic `mapwindow` (e.g., medfilt)

### DIFF
--- a/src/border.jl
+++ b/src/border.jl
@@ -289,9 +289,6 @@ padarray(img::AbstractArray, f::Fill) = padarray(eltype(img), img, f)
     padindex(border::Pad, lo::Integer, inds::AbstractUnitRange, hi::Integer)
 
 Generate an index-vector to be used for padding. `inds` specifies the image indices along a particular axis; `lo` and `hi` are the amount to pad on the lower and upper, respectively, sides of this axis. `border` specifying the style of padding.
-
-You can specialize this for custom `Pad{:name}` types to generate
-arbitrary (cartesian) padding types.
 """
 function padindex(border::Pad, lo::Integer, inds::AbstractUnitRange, hi::Integer)
     if border.style == :replicate
@@ -308,6 +305,11 @@ function padindex(border::Pad, lo::Integer, inds::AbstractUnitRange, hi::Integer
     else
         error("border style $(border.style) unrecognized")
     end
+end
+function padindex(border::Pad, inner::AbstractUnitRange, outer::AbstractUnitRange)
+    lo = max(0, first(inner)-first(outer))
+    hi = max(0, last(outer)-last(inner))
+    padindex(border, lo, inner, hi)
 end
 
 function inner(lo::Integer, inds::AbstractUnitRange, hi::Integer)

--- a/test/mapwindow.jl
+++ b/test/mapwindow.jl
@@ -70,6 +70,26 @@ using ImageFiltering, Base.Test
         Amin = groundtruth(min, A, w)
         @test minval == Amin
     end
-end
 
+    # median
+    for f in (median, median!)
+        a = [1,1,1,2,2,2]
+        @test mapwindow(f, a, -1:1) == a
+        @test mapwindow(f, a, (-1:1,)) == a
+        @test mapwindow(f, a, -2:2) == a
+        @test mapwindow(f, a, -3:3) == a
+        b = [1,100,1,2,-1000,2]
+        @test mapwindow(f, b, -1:1) == [1,1,2,1,2,2]
+        @test mapwindow(f, b, -2:2) == a
+
+        A = [1 5 -2 3 7;
+             2 0 3  4 4;
+             3 3 6  2 5;
+             1 -3 5 3 0]
+        @test mapwindow(f, A, (3,3)) == [1 1 3 3 4;
+                                         2 3 3 4 4;
+                                         2 3 3 4 4;
+                                         1 3 3 3 2]
+    end
+end
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ include("triggs.jl")
 include("cascade.jl")
 include("specialty.jl")
 include("gradient.jl")
-include("rank.jl")
+include("mapwindow.jl")
 include("basic.jl")
 include("deprecated.jl")
 


### PR DESCRIPTION
We've long had several "holes" in Images, of which one is not having a median filter. This PR implements a generic `mapwindow(f, img, window)` for performing linear or nonlinear operations on rectangular "moving windows" of the image. This is an `O(N^d)` algorithm (where `d` is dimensionality and `N` the window size), so it's not efficient for big windows, but it behaves pretty well for small windows.

For example, let's try `median!`:
```julia
julia> img = rand(1000,1000);

julia> @time mapwindow(median!, img, (3,3));
  0.179863 seconds (144.01 k allocations: 13.309 MB)
```
which is within 30% of Matlab on my machine (and I suspect Matlab is using multithreading, though I didn't check).

The nice thing about this implementation is that in principle, you can pass *any* function to `mapwindow`: e.g., `maximum`, `quantile`, `std`. Functions like `quantile`, which only support `AbstractVector`s, need a little extra care (as described in the docstring).

This doesn't preclude a special-purpose implementation for something like `median!` that gets better than `O(N^d)` behavior (indeed, `extrema` already has an efficient specialization), but I felt the most important thing was to get a flexible, generic algorithm in place. 