### PR TITLE
explicitly build docs on 0.5

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,4 +8,5 @@ makedocs(modules  = [ImageFiltering, Kernel, KernelFactors],
 deploydocs(repo   = "github.com/JuliaImages/ImageFiltering.jl.git",
            target = "build",
            deps   = nothing,
-           make   = nothing)
+           make   = nothing,
+           julia  = "0.5")


### PR DESCRIPTION
Documenter.jl defaults to the nightly linux build (see https://juliadocs.github.io/Documenter.jl/latest/lib/public.html#Documenter.deploydocs), which is more likely to break than the stable linux build. Fixes #18