### PR TITLE
Fix padding for inputs with non-1 indices

### DIFF
--- a/src/border.jl
+++ b/src/border.jl
@@ -295,16 +295,17 @@ Generate an index-vector to be used for padding. `inds` specifies the image indi
 """
 function padindex(border::Pad, lo::Integer, inds::AbstractUnitRange, hi::Integer)
     if border.style == :replicate
-        return vcat(fill(first(inds), lo), PinIndices(inds), fill(last(inds), hi))
+        indsnew = vcat(fill(first(inds), lo), inds, fill(last(inds), hi))
+        OffsetArray(indsnew, first(inds)-lo:last(inds)+hi)
     elseif border.style == :circular
         return modrange(extend(lo, inds, hi), inds)
     elseif border.style == :symmetric
-        I = [inds; reverse(inds)]
-        r = modrange(extend(lo, inds, hi), 1:2*length(inds))
+        I = OffsetArray([inds; reverse(inds)], (0:2*length(inds)-1)+first(inds))
+        r = modrange(extend(lo, inds, hi), indices(I, 1))
         return I[r]
     elseif border.style == :reflect
-        I = [inds; last(inds)-1:-1:first(inds)+1]
-        return I[modrange(extend(lo, inds, hi), 1:2*length(inds)-2)]
+        I = OffsetArray([inds; last(inds)-1:-1:first(inds)+1], (0:2*length(inds)-3)+first(inds))
+        return I[modrange(extend(lo, inds, hi), indices(I, 1))]
     else
         error("border style $(border.style) unrecognized")
     end

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -228,6 +228,10 @@ end
     b = @inferred(imfilter!(CPU1(Algorithm.FIR()), ret, a, (), NoPad()))
     @test b == a
     @test !(b === a)
+    # OffsetArrays
+    img = OffsetArray(rand(RGB{N0f8}, 80, 100), (-5, 3))
+    imgf = imfilter(img, Kernel.gaussian((3,3)))
+    @test indices(imgf) == indices(img)
 end
 
 nothing

--- a/test/nd.jl
+++ b/test/nd.jl
@@ -69,6 +69,18 @@ using Base.Test
     img[1] = img[8] = 0
     out = imfilter!(CPU1(Algorithm.FFT()), similar(img, Float64), img, kern, NoPad())
     @test out ≈ imfilter(img, kern)
+
+    # Inputs that have non-1 indices
+    img = OffsetArray(zeros(11), -5:5)
+    img[0] = 1
+    for border in ("replicate", "circular", "symmetric", "reflect",
+                   Fill(zero(eltype(img))), Inner(1), NA())
+        imgf = imfilter(img, centered([0.25, 0.5, 0.25]), border)
+        @test imgf[-1] == imgf[1] == 0.25
+        @test imgf[0] == 0.5
+        inds = indices(imgf,1)
+        @test all(x->x==0, imgf[first(inds):-2]) && all(x->x==0, imgf[2:last(inds)])
+    end
 end
 
 @testset "2d widening" begin


### PR DESCRIPTION
While this package exploits non-1 index arrays internally, it turns out I had never tested what happens if you filter an image with non-1 indices. The necessary fixes were gratifyingly modest (just to `padindex`).