### PR TITLE
make sure mapwindow() function reference is generated

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, ImageFiltering
 
-makedocs(modules  = [ImageFiltering, Kernel, KernelFactors],
+makedocs(modules  = [ImageFiltering, Kernel, KernelFactors, ImageFiltering.MapWindow],
          format   = Documenter.Formats.HTML,
          sitename = "ImageFiltering",
          pages    = ["index.md", "Function reference" => "function_reference.md"])


### PR DESCRIPTION
The function reference for `mapwindow()` is missing, which makes the link [here](https://juliaimages.github.io/ImageFiltering.jl/stable/index.html#Arbitrary-operations-over-sliding-windows-1) broken. I think we just need to tell Documenter to look inside the MapWindow module. 