### PR TITLE
RFC: strided mapwindow

### DIFF
--- a/src/mapwindow.jl
+++ b/src/mapwindow.jl
@@ -71,47 +71,146 @@ mapwindow(f, img, window::AbstractArray, args...; kwargs...) = mapwindow(f, img,
 function mapwindow(f,
                    img::AbstractArray{T,N},
                    window::Indices{N},
-                   border::BorderSpecAny;
+                   border::BorderSpecAny,
+                   imginds::NTuple{N, Range}=indices(img);
                    callmode=:copy!) where {T,N}
-    _mapwindow(replace_function(f), img, window, border, default_shape(f); callmode=callmode)
+    _mapwindow(replace_function(f), img, window, border, imginds, default_shape(f); callmode=callmode)
 end
+abstract type _IndexTransformer end
+
+struct _AffineTransformer{N} <: _IndexTransformer
+    offset::NTuple{N,Int}
+    stride::NTuple{N,Int}
+end
+function _AffineTransformer(ranges)
+end
+@inline function Base.getindex(t::_AffineTransformer, inds::CartesianIndex)
+    CartesianIndex(t.offset .+ t.stride .* inds.I)
+end
+
+struct _OffsetTransformer{N} <: _IndexTransformer
+    offset::NTuple{N,Int}
+end
+@inline function Base.getindex(t::_OffsetTransformer, inds::CartesianIndex)
+    CartesianIndex(t.offset .+ inds.I)
+end
+
+struct _IdentityTransformer <: _IndexTransformer end
+@inline Base.getindex(t::_IdentityTransformer, inds) = inds
+
+function _IndexTransformer(ranges)
+    stride = map(step, ranges)
+    offset1 = map(first, ranges)
+    offset = offset1 .- stride
+    _AffineTransformer(offset, stride)
+end
+
+function _IndexTransformer(ranges::NTuple{N,Base.OneTo}) where {N}
+    _IdentityTransformer()
+end
+
+function _IndexTransformer(ranges::NTuple{N,UnitRange}) where {N}
+    offset1 = map(first, ranges)
+    offset = offset1 .- 1
+    _OffsetTransformer(offset)
+end
+
+function unitrange_same_offset(r::Range)
+    a = first(r)
+    b = a + length(r) - 1
+    ret = a:b
+    @assert length(ret) == length(r)
+    @assert first(ret) == first(r)
+    ret
+end
+unitrange_same_offset(r::AbstractUnitRange) = r
+function unitindices_same_offset(ranges)
+    map(unitrange_same_offset, ranges)
+end
+
+# Return indices of elements of `r` that are also elements of `full`.
+function _intersectionindices(full::AbstractUnitRange, r::Range)
+    r_sub = intersect(full, r)
+    if isempty(r_sub)
+        ret = 1:0
+    else
+        ret = _indexof(r,first(r_sub)):_indexof(r,last(r_sub))
+    end
+    @assert intersect(full, r) == r[ret]
+    ret
+end
+
+function _indexof(r::Range, x)
+    T = eltype(r)
+    @assert x ∈ r
+    i = one(T) + T((x - first(r)) / step(r))
+    @assert r[i] == x
+    i
+end
+
+function _indices_of_interiour_range(
+        fullimgr::AbstractUnitRange, 
+        imgr::Range,
+        kerr::Range)
+    kmin, kmax = extrema(kerr)
+    idx1 = _intersectionindices(fullimgr, kmin + imgr)
+    idx2 = _intersectionindices(fullimgr, kmax + imgr)
+    idx = intersect(idx1, idx2)
+    @assert imgr[idx] + kmin ⊆ fullimgr
+    @assert imgr[idx] + kmax ⊆ fullimgr
+    idx
+end
+
+function _indices_of_interiour_indices(fullimginds, imginds, kerinds)
+    map(_indices_of_interiour_range, fullimginds, imginds, kerinds)
+end
+
+# replace median by ... outside of _mapwindow_kernel
 function _mapwindow(f,
                     img::AbstractArray{T,N},
-                    window::Indices{N},
+                    window::NTuple{N,Range},
                     border::BorderSpecAny,
+                    imginds::NTuple{N, Range},
                     shape=default_shape(f);
-                    callmode=:copy!) where {T,N}
-    inds = indices(img)
-    inner = _interior(inds, window)
-    if callmode == :copy!
-        buf = Array{T}(map(length, window))
-        bufrs = shape(buf)
-        Rbuf = CartesianRange(size(buf))
-        offset = CartesianIndex(map(w->first(w)-1, window))
-        # To allocate the output, we have to evaluate f once
-        Rinner = CartesianRange(inner)
-        if !isempty(Rinner)
-            Rwin = CartesianRange(map(+, window, first(Rinner).I))
-            copy!(buf, Rbuf, img, Rwin)
-            out = similar(img, typeof(f(bufrs)))
-            # Handle the interior
-            for I in Rinner
-                Rwin = CartesianRange(map(+, window, I.I))
-                copy!(buf, Rbuf, img, Rwin)
-                out[I] = f(bufrs)
-            end
-        else
-            copy_win!(buf, img, first(CartesianRange(inds)), border, offset)
-            out = similar(img, typeof(f(bufrs)))
-        end
-        # Now pick up the edge points we skipped over above
-        for I in EdgeIterator(inds, inner)
-            copy_win!(buf, img, I, border, offset)
-            out[I] = f(bufrs)
-        end
-    else
+                    callmode::Symbol=:copy!) where {T,N}
+    
+    if callmode != :copy!
         # TODO: implement :view
         error("callmode $callmode not supported")
+    end
+    outinds = unitindices_same_offset(imginds)
+    @assert map(length, imginds) == map(length, outinds)
+    
+    indind_full = map(r -> Base.OneTo(length(r)), imginds)
+    indind_inner = _indices_of_interiour_indices(indices(img), imginds, window)
+    Rindind_full = CartesianRange(indind_full)
+    Rindind_inner = CartesianRange(indind_inner)
+    
+    outindtrafo = _IndexTransformer(outinds)
+    imgindtrafo = _IndexTransformer(imginds)
+    
+    buf = Array{T}(map(length, window))
+    bufrs = shape(buf)
+    Rbuf = CartesianRange(size(buf))
+    # To allocate the output, we have to evaluate f once on realistic values
+    Iimg = imgindtrafo[first(Rindind_full)]
+    offset = CartesianIndex(map(w->first(w)-1, window))
+    copy_win!(buf, img, Iimg, border, offset)
+    out = similar(img, typeof(f(bufrs)), outinds)
+    for II ∈ Rindind_inner
+        Iimg = imgindtrafo[II]
+        Iout = outindtrafo[II]
+        Rwin = CartesianRange(map(+, window, Iimg.I))
+        copy!(buf, Rbuf, img, Rwin)
+        @inbounds out[Iout] = f(bufrs)
+    end
+    # Now pick up the edge points we skipped over above
+    Rindind_edge = EdgeIterator(Rindind_full, Rindind_inner)
+    for II ∈ Rindind_edge
+        Iimg = imgindtrafo[II]
+        Iout = outindtrafo[II]
+        copy_win!(buf, img, Iimg, border, offset)
+        out[Iout] = f(bufrs)
     end
     out
 end

--- a/test/mapwindow.jl
+++ b/test/mapwindow.jl
@@ -100,9 +100,13 @@ using ImageFiltering, Base.Test
             (median!, randn(10), (-1:1,), (1:2:8,)),
             (mean, randn(10), (-1:1,), (1:2:8,)),
             (mean, randn(10,5), (-1:1,0:0), (1:2:8,1:3)),
+            (mean, randn(10,5), (-1:1,0:0), (Base.OneTo(2),1:3)),
         ]
-        border = ImageFiltering.borderinstance("replicate")
-        @test mapwindow(f,img,window,border,imginds) == groundtruth(f,img,window,border,imginds)
+        border = "replicate"
+        @test groundtruth(f,img,window,border,imginds) == @inferred mapwindow(f,img,window,border,imginds)
     end
+    @test mapwindow(mean, randn(10), (3,), "replicate", 2:2:7) isa Array
+    @test mapwindow(mean, randn(10), (3,), "replicate", 2:7) isa OffsetArray
+    @test mapwindow(mean, randn(10), (3,)) isa Array
 end
 nothing

--- a/test/mapwindow.jl
+++ b/test/mapwindow.jl
@@ -91,5 +91,18 @@ using ImageFiltering, Base.Test
                                          2 3 3 4 4;
                                          1 3 3 3 2]
     end
+
+    function groundtruth(f, A, window::Tuple, border, imginds)
+        mapwindow(f,A,window,border)[imginds...]
+    end
+    for (f,img, window, imginds) ∈ [
+            (mean, randn(10), (1,), (1:2:10,)),
+            (median!, randn(10), (-1:1,), (1:2:8,)),
+            (mean, randn(10), (-1:1,), (1:2:8,)),
+            (mean, randn(10,5), (-1:1,0:0), (1:2:8,1:3)),
+        ]
+        border = ImageFiltering.borderinstance("replicate")
+        @test mapwindow(f,img,window,border,imginds) == groundtruth(f,img,window,border,imginds)
+    end
 end
 nothing

--- a/test/mapwindow.jl
+++ b/test/mapwindow.jl
@@ -105,8 +105,11 @@ using ImageFiltering, Base.Test
         border = "replicate"
         @test groundtruth(f,img,window,border,imginds) == @inferred mapwindow(f,img,window,border,imginds)
     end
-    @test mapwindow(mean, randn(10), (3,), "replicate", 2:2:7) isa Array
-    @test mapwindow(mean, randn(10), (3,), "replicate", 2:7) isa OffsetArray
-    @test mapwindow(mean, randn(10), (3,)) isa Array
+    for (inds, args) ∈ [((Base.OneTo(3),), ("replicate", 2:2:7)),
+                        ((2:7,), ("replicate", 2:7)),
+                        ((Base.OneTo(10),), ())
+                       ]
+        @test inds == indices(mapwindow(mean, randn(10), (3,), args...))
+    end
 end
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ aif = detect_ambiguities(ImageFiltering, Kernel, KernelFactors, Base)
 asa = detect_ambiguities(StaticArrays, Base)
 @test isempty(setdiff(aif, asa))
 
+include("mapwindow.jl")
 include("border.jl")
 include("nd.jl")
 include("2d.jl")
@@ -12,7 +13,6 @@ include("triggs.jl")
 include("cascade.jl")
 include("specialty.jl")
 include("gradient.jl")
-include("mapwindow.jl")
 include("basic.jl")
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,6 @@ aif = detect_ambiguities(ImageFiltering, Kernel, KernelFactors, Base)
 asa = detect_ambiguities(StaticArrays, Base)
 @test isempty(setdiff(aif, asa))
 
-include("mapwindow.jl")
 include("border.jl")
 include("nd.jl")
 include("2d.jl")
@@ -13,6 +12,7 @@ include("triggs.jl")
 include("cascade.jl")
 include("specialty.jl")
 include("gradient.jl")
+include("mapwindow.jl")
 include("basic.jl")
 
 nothing


### PR DESCRIPTION
See #44. Here is a first implementation. The API is a bit cumbersome and needs to be improved. Currently you have to call 
```julia
mapwindow(f,img,window,border,imginds)
```
Any suggestions for a better API? I would also like to add two convenience functions:
* `strided(inds, stride)` converts a stride into something that can be passed to mapwindow:
```julia
mapwindow(f,...,strided(indices(img), (2,3))) = mapwindow(f,...)[1:2:end,1:3:end]
```
* `mappool(f,img,window)` which does image [pooling](https://discourse.julialang.org/t/image-pooling/5280). This is the special case, where the stride is the size of the window.
```julia
mappool(f,img,window,...) = mapwindow(f,img,...,strided(indices(img), map(length,window))
```
