### PR TITLE
Fix0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7-alpha
 FixedPointNumbers 0.3.0
 Colors
 ColorVectorSpace

--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -2,8 +2,9 @@ __precompile__()
 
 module ImageFiltering
 
-importall FFTW
+import FFTW
 using Colors, FixedPointNumbers, ImageCore, MappedArrays, FFTViews, OffsetArrays, StaticArrays, ComputationalResources, TiledIteration
+using Statistics
 using ColorVectorSpace  # for filtering RGB arrays
 using Compat
 using Base: Indices, tail, fill_to_length, @pure, depwarn
@@ -25,7 +26,7 @@ OffsetVector{T} = OffsetArray{T,1}
 
 # Needed for type-stability
 function Base.transpose(A::StaticOffsetArray{T,2}) where T
-    inds1, inds2 = indices(A)
+    inds1, inds2 = axes(A)
     OffsetArray(transpose(parent(A)), inds2, inds1)
 end
 

--- a/src/border.jl
+++ b/src/border.jl
@@ -54,7 +54,7 @@ struct Pad{N} <: AbstractBorder
 end
 
 Pad{N}(style, lo::AbstractVector, hi::AbstractVector) where {N} =
-    Pad{N}(style, (lo...), (hi...))
+    Pad{N}(style, (lo...,), (hi...,))
 
 const valid_borders = ("replicate", "circular", "reflect", "symmetric")
 
@@ -110,7 +110,7 @@ Given a filter array `kernel`, determine the amount of padding from the `indices
 # Padding for FFT: round up to next size expressible as 2^m*3^n
 function (p::Pad{0})(kernel, img, ::FFT)
     inds = calculate_padding(kernel)
-    newinds = map(padfft, inds, map(length, indices(img)))
+    newinds = map(padfft, inds, map(length, axes(img)))
     Pad(p.style, newinds)
 end
 function padfft(indk::AbstractUnitRange, l::Integer)
@@ -122,7 +122,7 @@ function padindices(img::AbstractArray{_,N}, border::Pad) where {_,N}
     throw(ArgumentError("$border lacks the proper padding sizes for an array with $(ndims(img)) dimensions"))
 end
 function padindices(img::AbstractArray{_,N}, border::Pad{N}) where {_,N}
-    _padindices(border, border.lo, indices(img), border.hi)
+    _padindices(border, border.lo, axes(img), border.hi)
 end
 function padindices(img::AbstractArray, ::Type{P}) where P<:Pad
     throw(ArgumentError("must supply padding sizes to $P"))
@@ -156,11 +156,11 @@ padarray(img, ::Type{P}) where {P} = img[padindices(img, P)...]      # just to t
 
 function copydata!(dest, img, inds)
     isempty(inds) && return dest
-    idest = indices(dest)
+    idest = axes(dest)
     # Work around julia #9080
     i1, itail = idest[1], tail(idest)
     inds1, indstail = inds[1], tail(inds)
-    @unsafe for I in CartesianRange(itail)
+    @unsafe for I in CartesianIndices(itail)
         J = CartesianIndex(map((i,x)->x[i], I.I, indstail))
         for i in i1
             j = inds1[i]
@@ -233,7 +233,7 @@ end
 
 padarray(img, border::Inner) = padarray(eltype(img), img, border)
 padarray(::Type{T}, img::AbstractArray{T}, border::Inner) where {T} = copy(img)
-padarray(::Type{T}, img::AbstractArray, border::Inner) where {T} = copy!(similar(Array{T}, indices(img)), img)
+padarray(::Type{T}, img::AbstractArray, border::Inner) where {T} = copy!(similar(Array{T}, axes(img)), img)
 
 """
     Fill(val)
@@ -267,7 +267,7 @@ Fill(value, kernel) = Fill(value, calculate_padding(kernel))
 (p::Fill)(kernel, img, ::Alg) = Fill(p.value, kernel)
 function (p::Fill)(kernel, img, ::FFT)
     inds = calculate_padding(kernel)
-    newinds = map(padfft, inds, map(length, indices(img)))
+    newinds = map(padfft, inds, map(length, axes(img)))
     Fill(p.value, newinds)
 end
 
@@ -275,13 +275,13 @@ function padarray(::Type{T}, img::AbstractArray, border::Fill) where T
     throw(ArgumentError("$border lacks the proper padding sizes for an array with $(ndims(img)) dimensions"))
 end
 function padarray(::Type{T}, img::AbstractArray{S,N}, f::Fill{_,N}) where {T,S,_,N}
-    A = similar(arraytype(img, T), map((l,r,h)->first(r)-l:last(r)+h, f.lo, indices(img), f.hi))
+    A = similar(arraytype(img, T), map((l,r,h)->first(r)-l:last(r)+h, f.lo, axes(img), f.hi))
     try
         fill!(A, f.value)
     catch
         error("Unable to fill! an array of element type $(eltype(A)) with the value $(f.value). Supply an appropriate value to `Fill`, such as `zero(eltype(A))`.")
     end
-    A[indices(img)...] = img
+    A[axes(img)...] = img
     A
 end
 padarray(img::AbstractArray, f::Fill) = padarray(eltype(img), img, f)
@@ -301,11 +301,11 @@ function padindex(border::Pad, lo::Integer, inds::AbstractUnitRange, hi::Integer
         return modrange(extend(lo, inds, hi), inds)
     elseif border.style == :symmetric
         I = OffsetArray([inds; reverse(inds)], plus((0:2*length(inds)-1), first(inds)))
-        r = modrange(extend(lo, inds, hi), indices(I, 1))
+        r = modrange(extend(lo, inds, hi), axes(I, 1))
         return I[r]
     elseif border.style == :reflect
         I = OffsetArray([inds; last(inds)-1:-1:first(inds)+1], plus((0:2*length(inds)-3), first(inds)))
-        return I[modrange(extend(lo, inds, hi), indices(I, 1))]
+        return I[modrange(extend(lo, inds, hi), axes(I, 1))]
     else
         error("border style $(border.style) unrecognized")
     end
@@ -332,9 +332,9 @@ function extend(lo::Integer, inds::AbstractUnitRange, hi::Integer)
     OffsetArray(newind, newind)
 end
 
-calculate_padding(kernel) = indices(kernel)
+calculate_padding(kernel) = axes(kernel)
 @inline function calculate_padding(kernel::Tuple{Any, Vararg{Any}})
-    inds = accumulate_padding(indices(kernel[1]), tail(kernel)...)
+    inds = accumulate_padding(axes(kernel[1]), tail(kernel)...)
     if hasiir(kernel) && hasfir(kernel)
         inds = map(doublepadding, inds)
     end
@@ -359,7 +359,7 @@ function doublepadding(ind::AbstractUnitRange)
 end
 
 accumulate_padding(inds::Indices, kernel1, kernels...) =
-    accumulate_padding(expand(inds, indices(kernel1)), kernels...)
+    accumulate_padding(expand(inds, axes(kernel1)), kernels...)
 accumulate_padding(inds::Indices) = inds
 
 modrange(x, r::AbstractUnitRange) = mod(x-first(r), length(r))+first(r)
@@ -368,8 +368,8 @@ modrange(A::AbstractArray, r::AbstractUnitRange) = map(x->modrange(x, r), A)
 arraytype(A::AbstractArray, ::Type{T}) where {T} = Array{T}  # fallback
 arraytype(A::BitArray, ::Type{Bool}) = BitArray
 
-interior(A, kernel) = _interior(indices(A), indices(kernel))
-interior(A, factkernel::Tuple) = _interior(indices(A), accumulate_padding(indices(factkernel[1]), tail(factkernel)...))
+interior(A, kernel) = _interior(axes(A), axes(kernel))
+interior(A, factkernel::Tuple) = _interior(axes(A), accumulate_padding(axes(factkernel[1]), tail(factkernel)...))
 function _interior(indsA::NTuple{N}, indsk) where N
     indskN = fill_to_length(indsk, 0:0, Val(N))
     map(intersect, indsA, shrink(indsA, indsk))

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -157,7 +157,7 @@ DoG(σps::NTuple{N,Real}, σms::NTuple{N,Real}, ls::NTuple{N,Integer}) where {N}
 function DoG(σps::NTuple{N,Real}) where N
     σms = map(s->s*√2, σps)
     neg = gaussian(σms)
-    l = map(length, indices(neg))
+    l = map(length, axes(neg))
     gaussian(σps, l) - neg
 end
 DoG(σ::Real) = DoG((σ,σ))
@@ -174,7 +174,7 @@ See also: [`KernelFactors.IIRGaussian`](@ref) and [`Kernel.Laplacian`](@ref).
 """
 function LoG(σs::NTuple{N}) where N
     w = CartesianIndex(map(n->(ceil(Int,8.5*n)>>1), σs))
-    R = CartesianRange(-w, w)
+    R = CartesianIndices(-w, w)
     σ = SVector(σs)
     C = 1/(prod(σ)*(2π)^(N/2))
     σ2 = σ.^2
@@ -228,10 +228,10 @@ function Laplacian(dims, N::Int)
     Laplacian((flags...,))
 end
 
-Base.indices(L::Laplacian) = map(f->f ? (-1:1) : (0:0), L.flags)
+Base.axes(L::Laplacian) = map(f->f ? (-1:1) : (0:0), L.flags)
 Base.isempty(L::Laplacian) = false
 function Base.convert(::Type{AbstractArray}, L::Laplacian{N}) where N
-    A = fill!(OffsetArray{Int}(indices(L)), 0)
+    A = fill!(OffsetArray{Int}(axes(L)), 0)
     for I in L.offsets
         A[I] = A[-I] = 1
     end
@@ -248,9 +248,9 @@ Compute the pointwise reflection around 0, 0, ... of the kernel
 rather than correlation, with respect to the original `kernel`.
 """
 function reflect(kernel::AbstractArray)
-    inds = map(reflectind, indices(kernel))
+    inds = map(reflectind, axes(kernel))
     out = similar(kernel, inds)
-    for I in CartesianRange(indices(kernel))
+    for I in CartesianIndices(axes(kernel))
         out[-I] = kernel[I]
     end
     out

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -193,7 +193,7 @@ struct Laplacian{N}
     offsets::Vector{CartesianIndex{N}}
 
     function Laplacian{N}(flags::NTuple{N,Bool}) where {N}
-        offsets = Array{CartesianIndex{N}}(0)
+        offsets = Array{CartesianIndex{N}}(undef, 0)
         for i = 1:N
             if flags[i]
                 push!(offsets,

--- a/src/specialty.jl
+++ b/src/specialty.jl
@@ -3,7 +3,7 @@
 function _imfilter_inbounds!(r::AbstractResource, out, A::AbstractArray, L::Laplacian, border::NoPad, inds)
     TT = eltype(out) # accumtype(eltype(out), eltype(A))
     n = 2*length(L.offsets)
-    R = CartesianRange(inds)
+    R = CartesianIndices(inds)
     @unsafe for I in R
         tmp = convert(TT, - n * A[I])
         for J in L.offsets
@@ -39,7 +39,7 @@ provided as a dense or factored kernel, with factored representations
 recommended when the kernel is separable.
 """
 function imgradients(img::AbstractArray, kernelfun::Function, border="replicate")
-    extended = map(isextended, indices(img))
+    extended = map(isextended, axes(img))
     _imgradients((), img, kernelfun, extended, border)
 end
 
@@ -83,7 +83,7 @@ number of columns is the dimensionality of the array.
 """
 function imgradients(img::AbstractArray{T,N}, points::AbstractVector,
                      method=KernelFactors.ando3, border::AbstractString="replicate") where {T,N}
-    extended = map(isextended, indices(img))
+    extended = map(isextended, axes(img))
     npoints = length(points)
 
     # pad input image only on appropriate directions
@@ -104,7 +104,7 @@ function imgradients(img::AbstractArray{T,N}, points::AbstractVector,
             for (k, p) in enumerate(points)
                 icenter = CartesianIndex(ind2sub(extent, p))
                 i1 = CartesianIndex(tuple(ones(Int, ndirs)...))
-                for ii in CartesianRange(shape)
+                for ii in CartesianIndices(shape)
                     A[ii] = imgpad[ii + icenter - i1]
                 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,16 +19,16 @@ dummyind(::AbstractUnitRange) = 0:0
 dummykernel(inds::Indices{N}) where {N} = similar(dims->ones(ntuple(d->1,Val(N))), map(dummyind, inds))
 
 nextendeddims(inds::Indices) = sum(ind->length(ind)>1, inds)
-nextendeddims(a::AbstractArray) = nextendeddims(indices(a))
+nextendeddims(a::AbstractArray) = nextendeddims(axes(a))
 
 function checkextended(inds::Indices, n)
     dimstr = n == 1 ? "dimension" : "dimensions"
     nextendeddims(inds) != n && throw(ArgumentError("need $n extended $dimstr, got indices $inds"))
     nothing
 end
-checkextended(a::AbstractArray, n) = checkextended(indices(a), n)
+checkextended(a::AbstractArray, n) = checkextended(axes(a), n)
 
-ranges(R::CartesianRange) = map(colon, R.start.I, R.stop.I)
+ranges(R::CartesianIndices) = map(colon, R.start.I, R.stop.I)
 
 _reshape(A::OffsetArray{_,N}, ::Val{N}) where {_,N} = A
 _reshape(A::OffsetArray, ::Val{N}) where {N} = OffsetArray(reshape(parent(A), Val(N)), fill_to_length(A.offsets, -1, Val(N)))
@@ -38,7 +38,7 @@ _vec(a::AbstractVector) = a
 _vec(a::AbstractArray) = (checkextended(a, 1); a)
 _vec(a::OffsetArray{_,1}) where {_} = a
 function _vec(a::OffsetArray)
-    inds = indices(a)
+    inds = axes(a)
     checkextended(inds, 1)
     i = find(ind->length(ind)>1, inds)
     OffsetArray(vec(parent(a)), inds[i])
@@ -48,11 +48,11 @@ samedims(::Val{N}, kernel) where {N} = _reshape(kernel, Val(N))
 samedims(::Val{N}, kernel::Tuple) where {N} = map(k->_reshape(k, Val(N)), kernel)
 samedims(::AbstractArray{T,N}, kernel) where {T,N} = samedims(Val(N), kernel)
 
-@compat _tail(R::CartesianRange{0}) = R
-_tail(R::CartesianRange) = CartesianRange(CartesianIndex(tail(R.start.I)),
+@compat _tail(R::CartesianIndices{0}) = R
+_tail(R::CartesianIndices) = CartesianIndices(CartesianIndex(tail(R.start.I)),
                                           CartesianIndex(tail(R.stop.I)))
 
-to_ranges(R::CartesianRange) = map((b,e)->b:e, R.start.I, R.stop.I)
+to_ranges(R::CartesianIndices) = map((b,e)->b:e, R.start.I, R.stop.I)
 
 # ensure that overflow is detected, by ensuring that it doesn't happen
 # at intermediate stages of the computation

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -1,5 +1,5 @@
 using ImageFiltering, ImageCore, OffsetArrays, Colors, FFTViews, ColorVectorSpace, ComputationalResources, FixedPointNumbers
-using Base.Test
+using Test
 
 @testset "tiling" begin
     m = zeros(UInt8, 20, 20)
@@ -231,7 +231,7 @@ end
     # OffsetArrays
     img = OffsetArray(rand(RGB{N0f8}, 80, 100), (-5, 3))
     imgf = imfilter(img, Kernel.gaussian((3,3)))
-    @test indices(imgf) == indices(img)
+    @test axes(imgf) == axes(img)
 end
 
 nothing

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,4 +1,4 @@
-using ImageFiltering, OffsetArrays, Base.Test
+using ImageFiltering, OffsetArrays, Test
 
 @testset "basic" begin
     v = OffsetArray([1,2,3], -1:1)
@@ -35,9 +35,9 @@ using ImageFiltering, OffsetArrays, Base.Test
     @test isa(tiles, Vector{Matrix{Float32}})
     @test length(tiles) == 1
 
-    @test length(ImageFiltering.safetail(CartesianRange(()))) == 1
+    @test length(ImageFiltering.safetail(CartesianIndices(()))) == 1
     @test ImageFiltering.safetail(CartesianIndex(())) == CartesianIndex(())
-    @test length(ImageFiltering.safehead(CartesianRange(()))) == 1
+    @test length(ImageFiltering.safehead(CartesianIndices(()))) == 1
     @test ImageFiltering.safehead(CartesianIndex(())) == CartesianIndex(())
 
     # Warnings
@@ -60,7 +60,7 @@ using ImageFiltering, OffsetArrays, Base.Test
             redirect_stderr(OLDERR)
         end
     end
-    @test contains(readstring(fname), "too small for accuracy")
+    @test occursin("too small for accuracy", readstring(fname))
     rm(fname)
 end
 

--- a/test/border.jl
+++ b/test/border.jl
@@ -1,5 +1,5 @@
 using ImageFiltering, OffsetArrays, Colors, FixedPointNumbers
-using Base.Test
+using Test
 
 @testset "Border" begin
     @testset "padarray" begin
@@ -55,12 +55,12 @@ using Base.Test
              14   9  4   9  14  19  24  19  14;
              13   8  3   8  13  18  23  18  13], (-2,-2))
         ret = @test_throws ArgumentError padarray(A, Fill(0))
-        @test contains(ret.value.msg, "lacks the proper padding")
+        @test occursin("lacks the proper padding", ret.value.msg)
         for Style in (:replicate, :circular, :symmetric, :reflect)
             ret = @test_throws ArgumentError padarray(A, Pad(Style,(1,1,1),(1,1,1)))
-            @test contains(ret.value.msg, "lacks the proper padding")
+            @test occursin("lacks the proper padding", ret.value.msg)
             ret = @test_throws ArgumentError padarray(A, Pad(Style))
-            @test contains(ret.value.msg, "lacks the proper padding")
+            @test occursin("lacks the proper padding", ret.value.msg)
         end
         # arrays smaller than the padding
         A = [1 2; 3 4]
@@ -131,10 +131,10 @@ using Base.Test
         @test B != A
         A = rand(RGB{N0f8}, 3, 5)
         ret = @test_throws ErrorException padarray(A, Fill(0, (0,0), (0,0)))
-        @test contains(ret.value.msg, "element type ColorTypes.RGB")
+        @test occursin("element type ColorTypes.RGB", ret.value.msg)
         A = bitrand(3, 5)
         ret = @test_throws ErrorException padarray(A, Fill(7, (0,0), (0,0)))
-        @test contains(ret.value.msg, "element type Bool")
+        @test occursin("element type Bool", ret.value.msg)
         @test isa(parent(padarray(A, Fill(false, (1,1), (1,1)))), BitArray)
     end
 
@@ -151,7 +151,7 @@ using Base.Test
         a = reshape(1:15, 3, 5)
         targetinds = (OffsetArray([1,1,2,3,3], 0:4), OffsetArray([1:5;], 1:5))
         ret = @test_throws ArgumentError ImageFiltering.padindices(rand(3,5), Pad(:replicate,(1,)))
-        @test contains(ret.value.msg, "lacks the proper padding sizes")
+        @test occursin("lacks the proper padding sizes", ret.value.msg)
     end
 
 

--- a/test/cascade.jl
+++ b/test/cascade.jl
@@ -1,5 +1,5 @@
 using ImageFiltering, ImageCore, OffsetArrays, ComputationalResources
-using Base.Test
+using Test
 
 @testset "cascade" begin
     a = rand(15)

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -1,5 +1,5 @@
 using ImageFiltering, Colors, ColorVectorSpace, FixedPointNumbers
-using Base.Test, Compat  # Compat for ones(x, T)
+using Test, Compat  # Compat for ones(x, T)
 
 @testset "gradient" begin
     y, x = 1:5, (1:7)'
@@ -20,7 +20,7 @@ using Base.Test, Compat  # Compat for ones(x, T)
                 @test abs(val - ex) < 1e-4
             end
             gy, gx = imgradients(img, kernelfunc, Pad(:replicate))
-            @test indices(gy) == indices(gx) == indices(img)
+            @test axes(gy) == axes(gx) == axes(img)
         end
         for funcpairs in ((Kernel.ando3, KernelFactors.ando3),
                           (Kernel.sobel, KernelFactors.sobel),

--- a/test/mapwindow.jl
+++ b/test/mapwindow.jl
@@ -1,11 +1,11 @@
-using ImageFiltering, Base.Test
+using ImageFiltering, Test
 
 @testset "mapwindow" begin
     function groundtruth(f, A, window::Tuple)
         Aex = copy(A)
         hshift = map(x->x>>1+1, window)
-        for Ishift in CartesianRange(window)
-            for I in CartesianRange(size(A))
+        for Ishift in CartesianIndices(window)
+            for I in CartesianIndices(size(A))
                 Aex[I] = f(Aex[I], A[map(d->clamp(I[d]+Ishift[d]-hshift[d], 1, size(A,d)), 1:ndims(A))...])
             end
         end

--- a/test/nd.jl
+++ b/test/nd.jl
@@ -1,5 +1,5 @@
 using ImageFiltering, OffsetArrays, ComputationalResources
-using Base.Test
+using Test
 
 @testset "1d" begin
     img = 1:8
@@ -78,7 +78,7 @@ using Base.Test
         imgf = imfilter(img, centered([0.25, 0.5, 0.25]), border)
         @test imgf[-1] == imgf[1] == 0.25
         @test imgf[0] == 0.5
-        inds = indices(imgf,1)
+        inds = axes(imgf,1)
         @test all(x->x==0, imgf[first(inds):-2]) && all(x->x==0, imgf[2:last(inds)])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
-using ImageFiltering, Base.Test
+using ImageFiltering, Test
+import StaticArrays
+using Random
 
 aif = detect_ambiguities(ImageFiltering, Kernel, KernelFactors, Base)
 # Because StaticArrays has ambiguities with Base, we have to "subtract" these

--- a/test/specialty.jl
+++ b/test/specialty.jl
@@ -1,5 +1,5 @@
 using ImageFiltering, ImageCore, OffsetArrays, Colors, FixedPointNumbers
-using Base.Test
+using Test
 
 @testset "specialty" begin
     @testset "Laplacian" begin
@@ -162,7 +162,7 @@ using Base.Test
             @test ImageFiltering.iscopy(kern)
         end
         for kern in (Kernel.gaussian((1.3,)), Kernel.gaussian((1.3,),(7,)))
-            @test kern ≈ gaussiancmp(1.3, indices(kern,1))
+            @test kern ≈ gaussiancmp(1.3, axes(kern,1))
         end
         @test KernelFactors.gaussian(2, 9) ≈ gaussiancmp(2, -4:4)
         k = KernelFactors.gaussian((2,3), (9,7))
@@ -194,7 +194,7 @@ using Base.Test
         @test abs(sum(Kernel.DoG(5))) < 1e-8
         @test Kernel.DoG(5) == Kernel.DoG((5,5))
         @test abs(sum(Kernel.DoG((5,), (7,), (21,)))) < 1e-8
-        @test indices(Kernel.DoG((5,), (7,), (21,))) == (-10:10,)
+        @test axes(Kernel.DoG((5,), (7,), (21,))) == (-10:10,)
     end
 
     @testset "LoG" begin

--- a/test/triggs.jl
+++ b/test/triggs.jl
@@ -1,5 +1,5 @@
 using ImageFiltering, Colors, ComputationalResources, FixedPointNumbers
-using Base.Test
+using Test
 
 # @testset "TriggsSdika" begin
 #     @testset "1d" begin


### PR DESCRIPTION
The tests still fail:
```julia
(v0.7) pkg> test ImageFiltering
  Updating registry at `~/.julia/registries/Uncurated`
  Updating git-repo `https://github.com/JuliaRegistries/Uncurated.git`
   Testing ImageFiltering
 Resolving package versions...
Skipping Base.active_repl
Skipping Base.active_repl_backend
Skipping Base.active_repl
Skipping Base.active_repl_backend
padarray: Test Failed at /home/dani/.julia/dev/ImageFiltering/test/border.jl:134
  Expression: occursin("element type ColorTypes.RGB", (ret.value).msg)
Stacktrace:
 [1] macro expansion at /home/dani/.julia/dev/ImageFiltering/test/border.jl:142 [inlined]
 [2] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v0.7/Test/src/Test.jl:1080 [inlined]
 [3] macro expansion at /home/dani/.julia/dev/ImageFiltering/test/border.jl:6 [inlined]
 [4] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v0.7/Test/src/Test.jl:1080 [inlined]
 [5] top-level scope at /home/dani/.julia/dev/ImageFiltering/test/border.jl:5 [inlined]
 [6] top-level scope at ./<missing>:0
Test Summary: | Pass  Fail  Total
Border        |   78     1     79
  padarray    |   51     1     52
  Pad         |    9            9
  Inner       |    7            7
  Fill        |    9            9
  misc        |    2            2
ERROR: LoadError: LoadError: Some tests did not pass: 78 passed, 1 failed, 0 errored, 0 broken.
in expression starting at /home/dani/.julia/dev/ImageFiltering/test/border.jl:4
in expression starting at /home/dani/.julia/dev/ImageFiltering/test/runtests.jl:10
ERROR: Package ImageFiltering errored during testing
```