### PR TITLE
CartesianRange fixes

### DIFF
--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -1610,14 +1610,14 @@ alg_defaults(alg::Alg, out, kernel) = alg
 # Splitting out the first dimension saves a branch
 safetail(R::CartesianRange) = CartesianRange(CartesianIndex(tail(R.start.I)),
                                              CartesianIndex(tail(R.stop.I)))
-safetail(R::CartesianRange{CartesianIndex{1}}) = CartesianRange(())
-safetail(R::CartesianRange{CartesianIndex{0}}) = CartesianRange(())
+@compat safetail(R::CartesianRange{1}) = CartesianRange(())
+@compat safetail(R::CartesianRange{0}) = CartesianRange(())
 safetail(I::CartesianIndex) = CartesianIndex(tail(I.I))
 safetail(::CartesianIndex{1}) = CartesianIndex(())
 safetail(::CartesianIndex{0}) = CartesianIndex(())
 
 safehead(R::CartesianRange) = R.start[1]:R.stop[1]
-safehead(R::CartesianRange{CartesianIndex{0}}) = CartesianRange(())
+@compat safehead(R::CartesianRange{0}) = CartesianRange(())
 safehead(I::CartesianIndex) = I[1]
 safehead(::CartesianIndex{0}) = CartesianIndex(())
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -48,7 +48,7 @@ samedims(::Type{Val{N}}, kernel) where {N} = _reshape(kernel, Val{N})
 samedims(::Type{Val{N}}, kernel::Tuple) where {N} = map(k->_reshape(k, Val{N}), kernel)
 samedims(::AbstractArray{T,N}, kernel) where {T,N} = samedims(Val{N}, kernel)
 
-_tail(R::CartesianRange{CartesianIndex{0}}) = R
+@compat _tail(R::CartesianRange{0}) = R
 _tail(R::CartesianRange) = CartesianRange(CartesianIndex(tail(R.start.I)),
                                           CartesianIndex(tail(R.stop.I)))
 


### PR DESCRIPTION
When I try to run this package with the latest Julia 0.7 beta I get errors of the form

```
ERROR: LoadError: LoadError: TypeError: in apply_type, in Vararg count, expected Int64, got Type{CartesianIndex{0}}
```

during precompilation. With these changes I no longer get the errors. But I don't know much about this so this could be totally the wrong thing to do.