### PR TITLE
fix remaining depwarn

### DIFF
--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -1271,7 +1271,7 @@ function _imfilter_inplace_tuple!(r, out, img, kernel, Rbegin, inds, Rend, borde
                              out,
                              out,
                              tail(kernel),
-                             CartesianIndices(Rbegin.indices..., ind),
+                             CartesianIndices((Rbegin.indices..., ind)),
                              tail(inds),
                              _tail(Rend),
                              border)

--- a/test/triggs.jl
+++ b/test/triggs.jl
@@ -66,6 +66,12 @@ using Test
         imfilter!(CPU1(Algorithm.IIR()), out, imgf, KernelFactors.IIRGaussian(σ), 2, "replicate")
         @test out == ret
 
+        # for code coverage
+        # TODO: make into an actual test
+        kerng = KernelFactors.IIRGaussian(σ)
+        kern = (kerng,kerng)
+        imfilter(imgf, kern, NA())
+
         # When the image has NaNs
         imgfnan = copy(imgf)
         imgfnum = copy(imgf)


### PR DESCRIPTION
This depwarn was caught by the Images.jl tests (but not the tests of this package I think)

```
┌ Warning: `CartesianIndices(inds::Vararg{AbstractUnitRange{Int}, N}) where N` is deprecated, use `CartesianIndices(inds)` instead.
│   caller = _imfilter_inplace_tuple! at imfilter.jl:1270 [inlined]
└ @ Core ~/.julia/dev/ImageFiltering/src/imfilter.jl:1270
```