### PR TITLE
mapwindow arguments positional to keywords

### DIFF
--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -5,6 +5,7 @@ imfilter
 imfilter!
 imgradients
 mapwindow
+mapwindow!
 ```
 
 # Kernel
@@ -73,4 +74,3 @@ Algorithm.Mixed
 ```@docs
 KernelFactors.ReshapedOneD
 ```
-

--- a/src/mapwindow.jl
+++ b/src/mapwindow.jl
@@ -438,7 +438,13 @@ end
 default_shape(::Any) = identity
 default_shape(::typeof(median_fast!)) = vec
 
-@deprecate mapwindow(f, img, window, border, indices=axes(img)) mapwindow(f,img,window,border=border,indices=imginds)
-@deprecate mapwindow!(f, out, img, window, border, indices=axes(img)) mapwindow!(f,out,img,window,border=border,indices=imginds)
+@deprecate mapwindow(f, img, window, border,
+                     indices=default_imginds(img,window,border)) begin
+    mapwindow(f,img,window,border=border,indices=indices)
+end
+@deprecate mapwindow!(f, out, img, window, border,
+                      indices=default_imginds(img,window,border)) begin 
+    mapwindow!(f,out,img,window,border=border,indices=indices)
+end
 
 end


### PR DESCRIPTION
Now that Julia has fast keyword arguments, I think we should make use of them to shorten some signatures. This PR is for `mapwindow` and `mapwindow!`. 

I also looked at `imfilter` and `imfilter!`. These would in principle profit from some keyword arguments as well. However
* I personally do not use the more advanced signatures in `imfilter` and `imfilter!`
* There is a lot of "dispatch code" for `imfilter` and `imfilter!` already, which I am not familiar with. While I could blindly add yet another layer, I think it would be much better if a power user of these functions does this properly.
So I prefer not to touch `imfilter` and `imfilter!`, at least for this PR.