### PR TITLE
Improve (?) deprecation warning in #75

### DIFF
--- a/src/mapwindow.jl
+++ b/src/mapwindow.jl
@@ -438,12 +438,24 @@ end
 default_shape(::Any) = identity
 default_shape(::typeof(median_fast!)) = vec
 
-@deprecate mapwindow(f, img, window, border,
-                     indices=default_imginds(img,window,border)) begin
+## Deprecations
+function mapwindow(f, img, window, border)
+    Base.depwarn("mapwindow(f, img, window, $border) is deprecated, use `mapwindow(f, img, window, border=$border)` instead.", :mapwindow)
+    mapwindow(f,img,window,border=border)
+end
+
+function mapwindow(f, img, window, border, indices)
+    Base.depwarn("mapwindow(f, img, window, $border, $indices) is deprecated, use `mapwindow(f, img, window, border=$border, indices=$indices)` instead.", :mapwindow)
     mapwindow(f,img,window,border=border,indices=indices)
 end
-@deprecate mapwindow!(f, out, img, window, border,
-                      indices=default_imginds(img,window,border)) begin 
+
+function mapwindow!(f, out, img, window, border)
+    Base.depwarn("mapwindow!(f, out, img, window, $border) is deprecated, use `mapwindow!(f, out, img, window, border=$border)` instead.", :mapwindow!)
+    mapwindow!(f,out,img,window,border=border)
+end
+
+function mapwindow!(f, out, img, window, border, indices)
+    Base.depwarn("mapwindow!(f, out, img, window, $border, $indices) is deprecated, use `mapwindow!(f, out, img, window, border=$border, indices=$indices)` instead.", :mapwindow!)
     mapwindow!(f,out,img,window,border=border,indices=indices)
 end
 


### PR DESCRIPTION
I was going through some old emails and realized none of us had tagged a release containing #75. But then I tested and found the following deprecation warning a bit opaque:
```julia
julia> mapwindow!(identity, out, A, (0:1, 0:1), Inner())
┌ Warning: `mapwindow!(f, out, img, window, border, indices=default_imginds(img, window, border))` is deprecated, use `begin
│     mapwindow!(f, out, img, window, border=border, indices=indices)
│ end` instead.
│   caller = mapwindow!(::Function, ::Array{SArray{Tuple{4},Float64,1,4},2}, ::Array{Float64,2}, ::Tuple{UnitRange{Int64},UnitRange{Int64}}, ::Inner{0}) at deprecated.jl:54
└ @ ImageFiltering.MapWindow ./deprecated.jl:54
```

This PR changes it to
```julia
julia> mapwindow!(identity, out, A, (0:1, 0:1), Inner())
┌ Warning: mapwindow!(f, out, img, window, Inner{0}((), ())) is deprecated, use `mapwindow!(f, out, img, window, border=Inner{0}((), ()))` instead.
│   caller = top-level scope at none:0
└ @ Core none:0
```
which I think is better. (The line numbers are wrong, but that's true for both of them; the second is arguably more realistic.) It's still not perfect---`Inner{0}((), ())` is more complicated than `Inner()` which is what the user typed---but I think it's close enough that people may be able to recognize which argument they should pass as a keyword argument.

What do you think, @jw3126? An improvement, or not?