### PR TITLE
add and expose `psf2otf` and `otf2psf`

### DIFF
--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -9,7 +9,8 @@ using Base: Indices, tail, fill_to_length, @pure, depwarn, @propagate_inbounds
 export Kernel, KernelFactors, Pad, Fill, Inner, NA, NoPad, Algorithm,
     imfilter, imfilter!,
     mapwindow, mapwindow!,
-    imgradients, padarray, centered, kernelfactors, reflect
+    imgradients, padarray, centered, kernelfactors, reflect,
+    psf2otf, otf2psf
 
 FixedColorant{T<:Normed} = Colorant{T}
 StaticOffsetArray{T,N,A<:StaticArray} = OffsetArray{T,N,A}
@@ -39,6 +40,7 @@ using .Algorithm: Alg, FFT, FIR, FIRTiled, IIR, Mixed
 
 Alg(r::AbstractResource{A}) where {A<:Alg} = r.settings
 
+include("fft.jl")
 include("utils.jl")
 include("kernelfactors.jl")
 using .KernelFactors: TriggsSdika, IIRFilter, ReshapedOneD, iterdims, kernelfactors

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -1,0 +1,49 @@
+
+"""
+    otf = psf2otf(psf, [outsize = size(psf)])
+    otf = psf2otf(psf, dims...)
+
+    Convert point-spread function to optical transfer function
+
+    The tuple `outsize` can be used to specify the size of the `otf` array
+
+    See also: [`otf2psf`](@ref).
+"""
+function psf2otf(psf::AbstractArray{T,N}, outsize::Tuple{Vararg{Integer}}=size(psf)) where {T,N}
+  psf = repeat(psf, ones(Int,length(outsize))...) # reshape the dimension
+  psfsize = size(psf)
+
+  if psfsize != outsize
+    pad = outsize .- psfsize
+    all(x -> x >= 0, pad) || throw(DimensionMismatch("psf $psfsize too large for output otf $outsize."))
+    lo_dim = tuple(zeros(Int,length(pad))...)
+    hi_dim = pad
+    psf = padarray(psf,Fill(zero(T),lo_dim,hi_dim))
+  end
+
+  shift = @. -floor(Int, psfsize/2)
+  fft(circshift(psf, shift))
+end
+psf2otf(psf::AbstractArray, outsize::Integer...) = psf2otf(psf, tuple(outsize...))
+
+
+"""
+    psf = otf2psf(otf, [outsize = size(otf)])
+    psf = otf2psf(otf, dims...)
+
+    Convert optical transfer function to point-spread function
+
+    See also: [`psf2otf`](@ref).
+"""
+function otf2psf(otf::AbstractArray{T,N}, outsize::Tuple{Vararg{Integer}}=size(otf)) where {T,N}
+  otfsize = size(otf)
+  outsize = (outsize..., 
+        tuple(ones(Int, length(otfsize) - length(outsize))...)...)
+  all(otfsize >= outsize ) || throw(DimensionMismatch("output psf $outsize too large for otf $otfsize."))
+
+  psf = ifft(otf)
+  shift = @. floor(Int, outsize/2)
+  psf = circshift(psf,shift)
+  psf[map(x -> 1:x, outsize)...]
+end
+otf2psf(otf::AbstractArray, outsize::Integer...) = otf2psf(otf, tuple(outsize...))

--- a/test/fft.jl
+++ b/test/fft.jl
@@ -1,0 +1,76 @@
+@testset "fft" begin
+    @testset "interface" begin
+        @testset "1d" begin
+            xs = ([1, -1],
+                [1 -1])
+            good_szs = ((4,),
+                (4,4),
+                (4,4,4))
+            bad_szs = ((1,),
+                (1,1))
+
+            foreach(xs) do x
+                otf = @test_nowarn psf2otf(x)
+                psf = @test_nowarn otf2psf(otf)
+
+                foreach(good_szs) do sz
+                    @test_nowarn psf2otf(x, sz...)
+                    otf = @test_nowarn psf2otf(x, sz)
+                    @test_nowarn otf2psf(x, size(x)...)
+                    psf = @test_nowarn otf2psf(otf, size(x))
+                end
+
+                foreach(bad_szs) do sz
+                    @test_throws DimensionMismatch psf2otf(x, sz)
+                end
+            end
+        end
+    
+        @testset "2d" begin
+            x = [-1 0 1; -2 0 2; -1 0 1]
+            good_szs = (
+                (4,4),
+                (4,4,4))
+            bad_szs = ((1,),
+                (1,1))
+
+            otf = @test_nowarn psf2otf(x)
+            psf = @test_nowarn otf2psf(otf)
+
+            foreach(good_szs) do sz
+                @test_nowarn psf2otf(x, sz...)
+                otf = @test_nowarn psf2otf(x, sz)
+                @test_nowarn otf2psf(x, size(x)...)
+                psf = @test_nowarn otf2psf(otf, size(x))
+            end
+
+            foreach(bad_szs) do sz
+                @test_throws DimensionMismatch psf2otf(x, sz)
+            end
+            
+        end
+    end
+
+    @testset "numerical" begin
+        x = [1, -1]
+        otf_true = [0.0000 + 0.0000im   0.0000 + 0.0000im   0.0000 + 0.0000im   0.0000 + 0.0000im;
+            -1.0000 + 1.0000im  -1.0000 + 1.0000im  -1.0000 + 1.0000im  -1.0000 + 1.0000im;
+            -2.0000 + 0.0000im  -2.0000 + 0.0000im  -2.0000 + 0.0000im  -2.0000 + 0.0000im;
+            -1.0000 - 1.0000im  -1.0000 - 1.0000im  -1.0000 - 1.0000im  -1.0000 - 1.0000im]
+        otf = psf2otf(x, (4,4)) 
+        @test otf ≈ otf_true
+        @test otf2psf(otf, size(x)) ≈ x
+
+
+        x = [-1 0 1; -2 0 2; -1 0 1]
+        otf_true = [0.0000 + 0.0000im   0.0000 - 8.0000im   0.0000 + 0.0000im   0.0000 + 8.0000im;
+            0.0000 + 0.0000im   0.0000 - 4.0000im   0.0000 + 0.0000im   0.0000 + 4.0000im;
+            0.0000 + 0.0000im   0.0000 + 0.0000im   0.0000 + 0.0000im   0.0000 + 0.0000im;
+            0.0000 + 0.0000im   0.0000 - 4.0000im   0.0000 + 0.0000im   0.0000 + 4.0000im]
+        otf = psf2otf(x, (4,4)) 
+        @test otf ≈ otf_true
+        @test otf2psf(otf, size(x)) ≈ x
+    end
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,5 +17,6 @@ include("gradient.jl")
 include("mapwindow.jl")
 include("basic.jl")
 include("gabor.jl")
+include("fft.jl")
 
 nothing


### PR DESCRIPTION
Add commonly used functions `psf2otf` and `otf2psf`

Note:
The implementation mainly comes from the original MATLAB codes, e.g., `edit psf2otf`. The original code handles roundoff error, which in Julia there's no such need **(I guess? )**, so I skipped this part.

Reference:
http://www.mathworks.com/help/images/ref/psf2otf.html
http://www.mathworks.com/help/images/ref/otf2psf.html