### PR TITLE
Fixes for various Julia versions

### DIFF
--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -16,6 +16,13 @@ FixedColorant{T<:Normed} = Colorant{T}
 StaticOffsetArray{T,N,A<:StaticArray} = OffsetArray{T,N,A}
 OffsetVector{T} = OffsetArray{T,1}
 
+# Add a fix that should have been included in julia-1.0.3
+if isdefined(Broadcast, :_sametype) && !isdefined(Broadcast, :axistype)
+    axistype(a::T, b::T) where T = a
+    axistype(a, b) = UnitRange{Int}(a)
+    Broadcast._bcs1(a, b) = Broadcast._bcsm(b, a) ? axistype(b, a) : (Broadcast._bcsm(a, b) ? axistype(a, b) : throw(DimensionMismatch("arrays could not be broadcast to a common size")))
+end
+
 # Needed for type-stability
 function Base.transpose(A::StaticOffsetArray{T,2}) where T
     inds1, inds2 = axes(A)

--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -5,6 +5,7 @@ using Colors, FixedPointNumbers, ImageCore, MappedArrays, FFTViews, OffsetArrays
 using Statistics, LinearAlgebra
 using ColorVectorSpace  # for filtering RGB arrays
 using Base: Indices, tail, fill_to_length, @pure, depwarn, @propagate_inbounds
+using OffsetArrays: IdentityUnitRange   # using the one in OffsetArrays makes this work with multiple Julia versions
 
 export Kernel, KernelFactors, Pad, Fill, Inner, NA, NoPad, Algorithm,
     imfilter, imfilter!,

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -20,7 +20,7 @@ module Kernel
 using StaticArrays, OffsetArrays
 using ..ImageFiltering
 using ..ImageFiltering.KernelFactors
-import ..ImageFiltering: _reshape
+import ..ImageFiltering: _reshape, IdentityUnitRange
 
 # We would like to do `using ..ImageFiltering.imgradients` so that that
 # Documenter.jl (the documentation system) can parse a reference such as `See
@@ -263,7 +263,7 @@ See also: [`KernelFactors.IIRGaussian`](@ref) and [`Kernel.Laplacian`](@ref).
 """
 function LoG(σs::NTuple{N}) where N
     ws = map(n->(ceil(Int,8.5*n)>>1), σs)
-    R = CartesianIndices(map(w->Base.Slice(-w:w), ws))
+    R = CartesianIndices(map(w->IdentityUnitRange(-w:w), ws))
     σ = SVector(σs)
     C = 1/(prod(σ)*(2π)^(N/2))
     σ2 = σ.^2

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -1,6 +1,7 @@
 using ImageFiltering, ImageCore, OffsetArrays, Colors, FFTViews, ColorVectorSpace, ComputationalResources, FixedPointNumbers
 using LinearAlgebra
 using Test
+using ImageFiltering: IdentityUnitRange
 
 @testset "tiling" begin
     m = zeros(UInt8, 20, 20)
@@ -330,9 +331,11 @@ end
     @test r1[1,1] != r2[1,1]
 
     err = ArgumentError("Fill{$Int,1}(0, (3,), (3,)) lacks the proper padding sizes for an array with 2 dimensions")
-    @test_throws err imfilter(A, Kernel.gaussian((1,1),(3,3)), Fill(0, (3,)))
-    err = DimensionMismatch("requested indices (1:8, 0:9) and kernel indices (Base.Slice(-1:1), Base.Slice(0:0)) do not agree with indices of padded input, (Base.Slice(0:9), Base.Slice(1:8))")
-    @test_throws err imfilter(A, Kernel.gaussian((1,1),(3,3)), Fill(0, (1,0)))
-    @test_throws DimensionMismatch imfilter(A, Kernel.gaussian((1,1),(3,3)), Fill(0, (0,1)))
-    @test_throws DimensionMismatch imfilter(A, Kernel.gaussian((1,1),(3,3)), Fill(0, (0,0)))
+    kern = Kernel.gaussian((1,1),(3,3))
+    @test_throws err imfilter(A, kern, Fill(0, (3,)))
+    kernf = ImageFiltering.factorkernel(kern)
+    err = DimensionMismatch("requested indices (1:8, 0:9) and kernel indices $(axes(kernf[1])) do not agree with indices of padded input, $((IdentityUnitRange(0:9), IdentityUnitRange(1:8)))")
+    @test_throws err imfilter(A, kern, Fill(0, (1,0)))
+    @test_throws DimensionMismatch imfilter(A, kern, Fill(0, (0,1)))
+    @test_throws DimensionMismatch imfilter(A, kern, Fill(0, (0,0)))
 end

--- a/test/mapwindow.jl
+++ b/test/mapwindow.jl
@@ -1,4 +1,5 @@
 using ImageFiltering, Statistics, Test
+using ImageFiltering: IdentityUnitRange
 
 @testset "mapwindow" begin
     function groundtruth(f, A, window::Tuple)
@@ -123,7 +124,7 @@ using ImageFiltering, Statistics, Test
     img_48 = 10*collect(1:10)
     @test mapwindow(first, img_48, (1,), border=Inner()) == img_48
     res_48 = mapwindow(first, img_48, (0:1,), border=Inner())
-    @test axes(res_48) === (Base.Slice(1:9),)
+    @test axes(res_48) === (IdentityUnitRange(1:9),)
     @test res_48 == img_48[axes(res_48)...]
     inds_48 = 2:2:8
     @test mapwindow(first, img_48, (0:2,),

--- a/test/specialty.jl
+++ b/test/specialty.jl
@@ -1,5 +1,6 @@
 using ImageFiltering, ImageCore, OffsetArrays, Colors, FixedPointNumbers
 using Statistics, Test
+using ImageFiltering: IdentityUnitRange
 
 @testset "specialty" begin
     @testset "Laplacian" begin
@@ -164,17 +165,17 @@ using Statistics, Test
         for kern in (Kernel.gaussian((1.3,)), Kernel.gaussian((1.3,),(7,)))
             @test kern ≈ gaussiancmp(1.3, axes(kern,1))
         end
-        @test KernelFactors.gaussian(2, 9) ≈ gaussiancmp(2, Base.Slice(-4:4))
+        @test KernelFactors.gaussian(2, 9) ≈ gaussiancmp(2, IdentityUnitRange(-4:4))
         k = KernelFactors.gaussian((2,3), (9,7))
-        @test vec(k[1]) ≈ gaussiancmp(2, Base.Slice(-4:4))
-        @test vec(k[2]) ≈ gaussiancmp(3, Base.Slice(-3:3))
+        @test vec(k[1]) ≈ gaussiancmp(2, IdentityUnitRange(-4:4))
+        @test vec(k[2]) ≈ gaussiancmp(3, IdentityUnitRange(-3:3))
         @test sum(KernelFactors.gaussian(5)) ≈ 1
         for k = (KernelFactors.gaussian((2,3)), KernelFactors.gaussian([2,3]), KernelFactors.gaussian([2,3], [9,7]))
             @test sum(k[1]) ≈ 1
             @test sum(k[2]) ≈ 1
         end
-        @test Kernel.gaussian((2,), (9,)) ≈ gaussiancmp(2, Base.Slice(-4:4))
-        @test Kernel.gaussian((2,3), (9,7)) ≈ gaussiancmp(2, Base.Slice(-4:4)).*gaussiancmp(3, Base.Slice(-3:3))'
+        @test Kernel.gaussian((2,), (9,)) ≈ gaussiancmp(2, IdentityUnitRange(-4:4))
+        @test Kernel.gaussian((2,3), (9,7)) ≈ gaussiancmp(2, IdentityUnitRange(-4:4)).*gaussiancmp(3, IdentityUnitRange(-3:3))'
         @test sum(Kernel.gaussian(5)) ≈ 1
         for k = (Kernel.gaussian((2,3)), Kernel.gaussian([2,3]), Kernel.gaussian([2,3], [9,7]))
             @test sum(k) ≈ 1


### PR DESCRIPTION
The first commit gets the tests passing with the new `IdentityUnitRange` on Julia 1.1. The second is due to my failure to tag https://github.com/JuliaLang/julia/pull/30164 with a backport label.