### PR TITLE
Handle AxisArray and ImageMeta wrappers with `centered`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -12,3 +12,4 @@ FFTViews
 ComputationalResources
 DataStructures 0.4.6
 TiledIteration
+Requires

--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -6,6 +6,7 @@ using Statistics, LinearAlgebra
 using ColorVectorSpace  # for filtering RGB arrays
 using Base: Indices, tail, fill_to_length, @pure, depwarn, @propagate_inbounds
 using OffsetArrays: IdentityUnitRange   # using the one in OffsetArrays makes this work with multiple Julia versions
+using Requires
 
 export Kernel, KernelFactors, Pad, Fill, Inner, NA, NoPad, Algorithm,
     imfilter, imfilter!,
@@ -84,6 +85,13 @@ function __init__()
     #     @eval using DummyAF
     # end
     pop!(LOAD_PATH)
+    @require AxisArrays="39de3d68-74b9-583c-8d2d-e117c070f3a9" begin
+        centered(ax::AxisArrays.Axis{name}) where name = AxisArrays.Axis{name}(centered(ax.val))
+        centered(a::AxisArrays.AxisArray) = AxisArrays.AxisArray(centered(a.data), centered.(AxisArrays.axes(a)))
+    end
+    @require ImageMetadata="bc367c6b-8a6b-528e-b4bd-a4b897500b49" begin
+        centered(a::ImageMetadata.ImageMeta) = ImageMetadata.ImageMeta(centered(a.data), ImageMetadata.properties(a))
+    end
 end
 
 end # module

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+AxisArrays
+ImageMetadata

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,4 +1,6 @@
-using ImageFiltering, OffsetArrays, Logging, Test
+using ImageFiltering, OffsetArrays, Logging, ImageMetadata, Test
+import AxisArrays
+using AxisArrays: AxisArray, Axis
 
 @testset "basic" begin
     v = OffsetArray([1,2,3], -1:1)
@@ -57,6 +59,33 @@ using ImageFiltering, OffsetArrays, Logging, Test
     end
     @test occursin("too small for accuracy", read(fname, String))
     rm(fname)
+end
+
+@testset "centered" begin
+    check_range(r, f, l) = (@test first(r) == f; @test last(r) == l)
+    check_range_axes(r, f, l) = check_range(axes(r)[1], f, l)
+
+    check_range(axes(centered(1:3))[1], -1, 1)
+    a = AxisArray(rand(3, 3), Axis{:y}(0.1:0.1:0.3), Axis{:x}(1:3))
+    ca = centered(a)
+    axs = axes(ca)
+    check_range(axs[1], -1, 1)
+    check_range(axs[2], -1, 1)
+    axs = AxisArrays.axes(ca)
+    check_range(axs[1].val, 0.1, 0.3)
+    check_range(axs[2].val, 1, 3)
+    check_range_axes(axs[1].val, -1, 1)
+    check_range_axes(axs[1].val, -1, 1)
+    am = ImageMeta(a; prop1="simple")
+    ca = centered(am)
+    axs = axes(ca)
+    check_range(axs[1], -1, 1)
+    check_range(axs[2], -1, 1)
+    axs = AxisArrays.axes(ca)
+    check_range(axs[1].val, 0.1, 0.3)
+    check_range(axs[2].val, 1, 3)
+    check_range_axes(axs[1].val, -1, 1)
+    check_range_axes(axs[1].val, -1, 1)
 end
 
 nothing


### PR DESCRIPTION
This provides specializations for `centered`, where the conditional dependency on the relevant packages is handled via Requires.jl.