### PR TITLE
correct the behavior of centered for OffsetArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageFiltering"
 uuid = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,7 +12,6 @@ arbitrary axes.
 See also: [`imfilter`](@ref).
 """
 function centered(A::AbstractArray)
-    all(isodd.(size(A))) || error("entries must be odd, got $A")
     offsetted = first.(axes(A)) .- 1
     total_offsets = .-((size(A) .+ 1 ) .÷ 2)
     OffsetArray(A, total_offsets .- offsetted)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,12 @@ arbitrary axes.
 
 See also: [`imfilter`](@ref).
 """
-centered(A::AbstractArray) = OffsetArray(A, map(n->-((n+1)>>1), size(A)))
+function centered(A::AbstractArray)
+    all(isodd.(size(A))) || error("entries must be odd, got $A")
+    offsetted = first.(axes(A)) .- 1
+    total_offsets = .-((size(A) .+ 1 ) .÷ 2)
+    OffsetArray(A, total_offsets .- offsetted)
+end
 
 """
     kernfft = freqkernel([T::Type], kern, sz=size(kern); rfft=false)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -86,6 +86,16 @@ end
     check_range(axs[2].val, 1, 3)
     check_range_axes(axs[1].val, -1, 1)
     check_range_axes(axs[1].val, -1, 1)
+
+    a = rand(3, 3)
+    ca = centered(a)
+    cca = centered(ca)
+    c_view_a = centered(view(ca, :, 0:0))
+    c_slice_a = centered(a[:, 2:2])
+    @test a[2, 2] == ca[0, 0]
+    @test a[2, 2] == cca[0, 0]
+    @test a[2, 2] == c_view_a[0, 0]
+    @test a[2, 2] == c_slice_a[0, 0]
 end
 
 @testset "freqkernel/spacekernel" begin


### PR DESCRIPTION
This patch generalizes `centered(A::AbstractArray)` by not assuming indexes of A start at 1.

A side effect of this patch is to corrects the behavior of `imfilter` with accident usage of `centered(::OffsetArray)`

### Before:
```julia
julia> x = testimage("cameraman")

julia> k = KernelFactors.gaussian(1.5, 11)
OffsetArray(::Array{Float64,1}, -5:5) with eltype Float64 with indices -5:5:

julia> a = imfilter(x, kernelfactors((k, k)))

julia> b = imfilter(x, kernelfactors((centered(k), centered(k))))

julia> a - b
```

![image](https://user-images.githubusercontent.com/8684355/58512479-c2ec7300-81cf-11e9-8184-c33bfe9a0a58.png)

### After:
```julia
julia> gray.(sum(abs.(a-b)))
0.0
```
