### PR TITLE
[WIP] update benchmark script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+benchmark/tune.json
 docs/build
 docs/site
 Manifest.toml

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,4 +1,8 @@
 using ImageFiltering
-using PkgBenchmark
+using TestImages, ImageTransformations
+using BenchmarkTools
 
-include("mapwindow.jl")
+const SUITE = BenchmarkGroup(["ImageFIltering"])
+
+include("utils.jl")
+include("imfilter.jl")

--- a/benchmark/imfilter.jl
+++ b/benchmark/imfilter.jl
@@ -1,0 +1,39 @@
+SUITE["imfilter"] = BenchmarkGroup(["imfilter"])
+SUITE["imfilter_naive"] = BenchmarkGroup(["imfilter", "naive implementation"])
+SUITE["imfilter_naive"]["CPU1"] = BenchmarkGroup(["CPU", "single thread"])
+SUITE["imfilter"]["CPU1"] = BenchmarkGroup(["CPU", "single thread"])
+# SUITE["imfilter"]["CPUThread"] = BenchmarkGroup(["CPU", "multi threads"])
+# SUITE["imfilter"]["CUDA"] = BenchmarkGroup(["GPU", "CUDA"])
+# SUITE["imfilter"]["ArrayFire"] = BenchmarkGroup(["GPU", "ArrayFire"])
+# SUITE["imfilter"]["OpenCL"] = BenchmarkGroup(["GPU", "OpenCL"])
+
+img_gray_256 = testimage("lena_gray_256")
+img_rgb_256 = testimage("lena_color_256")
+img_list_gray = [imresize(img_gray_256, ratio=ratio) for ratio in (0.5, 1.0, 2.0, 4.0)]
+img_list_rgb = [imresize(img_rgb_256, ratio=ratio) for ratio in (0.5, 1.0, 2.0, 4.0)]
+
+default_kernel = centered(ones((31, 31))./prod((31, 31)))
+
+for (imfilter_impl, imfilter_name) in ((imfilter, "imfilter"),
+                                     (imfilter_naive, "imfilter_naive"))
+    SUITE[imfilter_name]["CPU1"]["image"] = BenchmarkGroup(["image"])
+    for img in img_list_gray
+        SUITE[imfilter_name]["CPU1"]["image"]["size", size(img)] =
+            @benchmarkable ($imfilter_impl)($img, default_kernel)
+    end
+
+    SUITE[imfilter_name]["CPU1"]["kernel"] = BenchmarkGroup(["kernel"])
+    for n in 1:2:19
+        w = 2n+1
+        kern = centered(ones((w, w))./prod((w, w)))
+        SUITE[imfilter_name]["CPU1"]["kernel"]["size", (w, w)] =
+            @benchmarkable ($imfilter_impl)(img_gray_256, $(kern))
+    end
+
+    SUITE[imfilter_name]["CPU1"]["padding"] = BenchmarkGroup(["padding style"])
+    for padding_style in ("replicate", "circular", "symmetric", "reflect")
+        # TODO: Inner(), NA(), NoPad()
+        SUITE[imfilter_name]["CPU1"]["padding"][padding_style] =
+            @benchmarkable ($imfilter_impl)(img_gray_256, default_kernel, $padding_style)
+    end
+end

--- a/benchmark/utils.jl
+++ b/benchmark/utils.jl
@@ -1,0 +1,13 @@
+function imfilter_naive(img, kernel, padding_style=:replicate)
+    padding_size = (size(kernel).-1).÷2
+    out = similar(img)
+    R = CartesianIndices(img)
+    img = padarray(img, Pad(padding_style, padding_size, padding_size))
+    offset = last(CartesianIndices(kernel))
+    for p in R
+        patch = img[p-offset:p+offset]
+        patch = centered(patch)
+        out[p] = sum(patch .* kernel)
+    end
+    out
+end


### PR DESCRIPTION
The current benchmark script is broken, so I redesign it. Hopefully, we can catch a bunch of performance bottleneck with it, and decide where the future efforts should be put on.

A comprehensive benchmark on `ImageFiltering` requires more utils and benchmark items, but I'd like to get some early feedback on this.

I plan to make the benchmark script a little bit redundancy so that we can get more performance information about `ImageFiltering`. However, this requires quite a long-running time on the local machine (e.g., ~4mins in i7-6700K CPU @ 4.00GHz in the first commit)

TODO:

- [ ] `imfilter`
  - [ ] algorithm specification
  - [ ] computational resource specification
  - [ ] kernel: separable or not
- [ ] `mapwindow`
- [ ] visualization of benchmark results
- [ ] easy-to-use benchmarking pipeline script