### PR TITLE
Don't use FFT when input has NaNs

### DIFF
--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -1532,7 +1532,7 @@ end
 # allocated by the time this gets called.
 function filter_algorithm(out, img, kernel::Union{ArrayType,Tuple{Vararg{ArrayType}}})
     L = maxlen(kernel)
-    if L > 30 && eltype(img) <: Union{Number,Colorant}
+    if L > 30 && eltype(img) <: Union{Number,Colorant} && !any(isnan,img)
         return FFT()
     end
     sz = map(length, calculate_padding(kernel))

--- a/test/nd.jl
+++ b/test/nd.jl
@@ -92,6 +92,9 @@ Base.zero(::Type{WrappedFloat}) = WrappedFloat(0.0)
         @test all(x->x==0, imgf[first(inds):-2]) && all(x->x==0, imgf[2:last(inds)])
     end
 
+    # Input with NaN
+    @test isnan.(imfilter([NaN;1:100],centered(ones(31)))) == ((0:100) .<= 15)
+
     # Issue #110
     img = reinterpret(WrappedFloat, rand(128))
     kern = centered(rand(31))


### PR DESCRIPTION
This fixes filtering of floating-point arrays with `NaN` and large kernels.
According to benchmarks on my machine, the time to check for `NaN`s is up to about 0.5% of the `imfilter` time (for `img::Vector{Float64}` and kernel of length 31).