### PR TITLE
Fix mapwindow for offset arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageFiltering"
 uuid = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 author = ["Tim Holy <tim.holy@gmail.com>", "Jan Weidner <jw3126@gmail.com>"]
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"
@@ -30,7 +30,7 @@ FFTW = "0.3, 1"
 ImageCore = "0.8.1"
 ImageMetadata = "0.9"  # it doesn't actually depend on ImageMetadata, but if present we want arraydata to work
 MappedArrays = "0.2"
-OffsetArrays = "0.10, 0.11, 1"
+OffsetArrays = "1.1"
 Requires = "0.5, 1.0"
 StaticArrays = "0.10, 0.11, 0.12"
 TiledIteration = "0.2"

--- a/src/mapwindow.jl
+++ b/src/mapwindow.jl
@@ -73,8 +73,9 @@ function mapwindow(f, img, window; border="replicate",
               resolve_imginds(indices))
 end
 
-# a unit range `r` having `r == axes(r)` which keeps its axes with
-# broadcasting (e.g., `axes(r.+1) == axes(r)`), unlike Base.IdentityUnitRange
+# a unit range `s` having the same values as `r` and `axes(s) == (s,)`,
+# which keeps its axes with broadcasting (e.g., `axes(s.+1) == axes(s)`),
+# unlike Base.IdentityUnitRange
 self_offset(r::AbstractUnitRange) = OffsetArrays.IdOffsetRange(1:length(r), first(r)-one(eltype(r)))
 
 function default_imginds(img, window, border)
@@ -198,7 +199,7 @@ function _intersectionindices(full::AbstractUnitRange, r::AbstractRange)
 end
 
 function _indexof(r::AbstractRange, x)
-    T = eltype(r)
+    T = eltype(axes(r,1))
     @assert x ∈ r
     i = T(firstindex(r) + (x - first(r)) / step(r))
     @assert r[i] == x

--- a/src/mapwindow.jl
+++ b/src/mapwindow.jl
@@ -210,9 +210,6 @@ function _indices_of_interiour_range(
     idx1 = _intersectionindices(fullimgr, kmin .+ imgr)
     idx2 = _intersectionindices(fullimgr, kmax .+ imgr)
     idx = intersect(idx1, idx2)
-    @assert imgr[idx] .+ kmin ⊆ fullimgr
-    @assert imgr[idx] .+ kmax ⊆ fullimgr
-    idx
 end
 
 function _indices_of_interiour_indices(fullimginds, imginds, kerinds)
@@ -375,7 +372,7 @@ extrema_filter(A::AbstractArray, window) = error("`window` must have the same nu
 
 extrema_filter(A::AbstractArray{T,N}, window::Integer) where {T,N} = extrema_filter(A, ntuple(d->window, Val{N}))
 
-function _extrema_filter!(A::Array, w1, w...)
+function _extrema_filter!(A::AbstractArray, w1, w...)
     if w1 > 1
         a = first(A)
         if w1 <= 20
@@ -396,7 +393,7 @@ function _extrema_filter!(A::Array, w1, w...)
         return A
     end
 end
-_extrema_filter!(A::Array) = A
+_extrema_filter!(A::AbstractArray) = A
 
 # Extrema-filtering along "columns" (dimension 1). This implements Lemire
 # Algorithm 1, with the following modifications:

--- a/test/mapwindow.jl
+++ b/test/mapwindow.jl
@@ -1,5 +1,6 @@
 using ImageFiltering, Statistics, Test
 using ImageFiltering: IdentityUnitRange
+using OffsetArrays
 
 @testset "mapwindow" begin
     function groundtruth(f, A, window::Tuple)
@@ -71,6 +72,19 @@ using ImageFiltering: IdentityUnitRange
         Amin = groundtruth(min, A, w)
         @test minval == Amin
     end
+    # offsets
+    @testset "offsets" begin
+        arrays = [rand(5), rand(5,5), rand(5,5,5)]
+        @testset "offsets ($f, $offset, $window, $dim)" for f in (extrema,maximum,minimum),
+                                                            offset in -5:5,
+                                                            window in [1:2:9; [0:2,-2:0]],
+                                                            (dim,a) in enumerate(arrays)
+            offsets = ntuple(_->offset,dim)
+            windows = ntuple(_->window,dim)
+            @test OffsetArray(mapwindow(f,a,windows),offsets) == mapwindow(f,OffsetArray(a,offsets),windows)
+        end
+    end
+
 
     # median
     for f in (median, median!)

--- a/test/mapwindow.jl
+++ b/test/mapwindow.jl
@@ -129,7 +129,7 @@ using OffsetArrays
         @test expected == @inferred mapwindow!(f,out,img,window,indices=imginds)
     end
     for (inds, kw) ∈ [((Base.OneTo(3),), (border="replicate", indices=2:2:7)),
-                        ((2:7,), (indices=2:7,)),
+                        (axes(2:7), (indices=2:7,)),
                         ((Base.OneTo(10),), ())
                        ]
         @test inds == axes(mapwindow(mean, randn(10), (3,); kw...))


### PR DESCRIPTION
The deleted assertions fail due to  JuliaArrays/OffsetArrays.jl#104. As a workaround, I tried
```
@assert (imgr .+ kmin)[idx] ⊆ fullimgr
@assert (imgr .+ kmax)[idx] ⊆ fullimgr
```
instead, but that fails due to JuliaLang/julia#35225 when `idx` turns out empty.