### PR TITLE
2D Tophat (Disk) Kernel

### DIFF
--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -24,6 +24,7 @@ Kernel.DoG
 Kernel.LoG
 Kernel.Laplacian
 Kernel.moffat
+Kernel.tophat
 ```
 
 # KernelFactors

--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -64,7 +64,7 @@ ArrayLike{T} = Union{ArrayType{T}, AnyIIR{T}}
 
 include("kernel.jl")
 using .Kernel
-using .Kernel: Laplacian, reflect, ando3, ando4, ando5, scharr, bickley, prewitt, sobel, gabor, moffat
+using .Kernel: Laplacian, reflect, ando3, ando4, ando5, scharr, bickley, prewitt, sobel, gabor, moffat, tophat
 
 NDimKernel{N,K} = Union{AbstractArray{K,N},ReshapedOneD{K,N},Laplacian{N}}
 

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -442,7 +442,7 @@ function tophat(r::Real, sizes::Tuple{Integer, Integer})
             kern[idx] = amplitude
         end
     end
-    return kern
+    return kern ./ sum(kern) # renormalize 
 end
 
 """

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -13,6 +13,7 @@ dimensionality. The following kernels are supported:
   - `Laplacian`
   - `gabor`
   - `moffat`
+  - `tophat`
 
 See also: [`KernelFactors`](@ref).
 """
@@ -414,6 +415,34 @@ moffat(α::Real, β::Real)                 = moffat(α, β, ceil(Int, (α*2*sqrt
 @inline function df(I::CartesianIndex)
     x = SVector(Tuple(I))
     sum(x.^2)
+end
+
+"""
+    tophat(r) -> k
+    tophat(r, ls) -> k
+
+Constructs a 2D Tophat kernel, or a 2D Disk kernel. The default size is the `2r` rounded up to the nearest odd integer.
+"""
+function tophat(r::Integer)
+    # default size: 2r rounded up to nearest odd integer
+    i = ceil(Int, 2 * r)
+    s = iseven(i) ? i + 1 : i
+    return tophat(r, (s, s))
+end
+
+function tophat(r::Real, sizes::Tuple{Integer, Integer})   
+    u, v = sizes
+    amplitude = inv(π * r^2)
+    kern = zeros(typeof(amplitude), u, v)
+
+    cy, cx = u / 2 + 0.5, v / 2 + 0.5
+    for idx in CartesianIndices(axes(kern))
+        x, y = idx.I
+        if (x - cx)^2 + (y - cy)^2 ≤ r^2
+            kern[idx] = amplitude
+        end
+    end
+    return kern
 end
 
 """


### PR DESCRIPTION
This adds a 2D "tophat" kernel. This is geometrically just a disk. I'm not an images guy, per se, so if there is a more apt name than `tophat`, please inform me! 

The two functions added to `Kernel` are 
* `tophat(r)` - default size is `2r` rounded up to the nearest odd integer. The cells whose distance from the center is less than or equal to `r` will be constant and all other will be zero. The constant will be such that the sum is 1. 
* `tophat(r, ls)` - the same as above, but allos user-input size `ls`. This will handle even and odd based shapes, and even mixes of both (eg `(6, 7)`. Again, the pixels whose distance from the center is less than or equal to `r` will be a normalized constant.

I've added a docstring and imported correctly under `ImageFiltering.jl`. I've added it to the `Kernel` module docstring, too. Unfortunately I'm not having a great time parsing the test suite, so I don't have any tests. Please let me know where I can test this.
