### PR TITLE
Generalize `NA` to take `na` predicate as argument (not just `isnan`)

### DIFF
--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -668,15 +668,18 @@ function _imfilter_na!(r::AbstractResource,
                        img::AbstractArray{T,N},
                        kernel::ProcessedKernel,
                        na) where {T,S,N}
-    naflag = na.(img)
-    hasnas = any(naflag)
-    if hasnas || !isseparable(kernel)
+    if !isseparable(kernel) || (naflag = _mapna(img,na); any(naflag))
         imfilter_na_inseparable!(r, out, img, naflag, kernel)
     else
         imfilter_na_separable!(r, out, img, kernel)
     end
     out
 end
+
+# for types that can't have NaNs, we can skip the isnan check
+_mapna(img::AbstractArray, na) = na.(img)
+_mapna(img::AbstractArray{T},
+       na::typeof(isnan)) where {T<:Union{Integer,FixedColorant}} = fill(false, axes(img))
 
 # Any other kind of not-fully-specified padding
 function imfilter!(r::AbstractResource,

--- a/test/border.jl
+++ b/test/border.jl
@@ -1,4 +1,4 @@
-using ImageFiltering, OffsetArrays, ImageCore, Random
+using ImageFiltering, OffsetArrays, ImageCore, Random, StaticArrays
 import OffsetArrays.IdentityUnitRange
 
 using Test
@@ -266,6 +266,20 @@ using Test
         @test @inferred(Fill(-1)(rand(3,5))) == Fill(-1, (0,0), (3,5))
         @test @inferred(Fill(-1)(centered(rand(3,5)))) == Fill(-1, (1,2), (1,2))
         @test @inferred(Fill(2)(Kernel.Laplacian(), rand(5,5), Algorithm.FIR())) == Fill(2, (1,1),(1,1))
+    end
+
+    @testset "NA" begin
+        @test imfilter(1:10, centered([1,1,1].//3), NA()) == [3//2; 2:9; 19//2]
+
+        x = [1,NaN,Inf,0,-Inf,Inf,NaN,NaN,1]
+        k = OffsetArray([1,1],0:1)
+        @test isequal(imfilter(x, k, NA()), [1,Inf,Inf,-Inf,NaN,Inf,NaN,1,1])
+        @test isequal(imfilter(x, k, NA(!isfinite)), [1,NaN,0,0,NaN,NaN,NaN,1,1])
+        @test isequal(imfilter(x, k, NA(x->false)), [NaN,NaN,Inf,-Inf,NaN,NaN,NaN,NaN,1])
+
+        v = SVector.([1,2,3],[1,NaN,3])
+        @test isequal(imfilter(v, OffsetArray([1,1],0:1), NA(x->any(isnan,x))),
+                      SVector.([1,3,3],[1,3,3]))
     end
 
     @testset "misc" begin

--- a/test/border.jl
+++ b/test/border.jl
@@ -280,6 +280,8 @@ using Test
         v = SVector.([1,2,3],[1,NaN,3])
         @test isequal(imfilter(v, OffsetArray([1,1],0:1), NA(x->any(isnan,x))),
                       SVector.([1,3,3],[1,3,3]))
+
+        @test imfilter(1:5, centered([1]), NA()) == 1:5
     end
 
     @testset "misc" begin


### PR DESCRIPTION
Useful for filtering `SVector` or `GeometryTypes.Point` arrays with `NA(x->any(isnan,x))`.
May be also useful to do `NA(ismissing)` in the future, but `imfilter` with `missing`s doesn't work yet for other reasons.

I removed the line `out[nanflag] .= nan(T)`, which may be breaking (changes the behavior of plain `NA()`). I'm not sure why it was there; seems to me like a bug.