### PR TITLE
Fix tests with ColorTypes 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageFiltering"
 uuid = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 author = ["Tim Holy <tim.holy@gmail.com>", "Jan Weidner <jw3126@gmail.com>"]
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"

--- a/test/border.jl
+++ b/test/border.jl
@@ -220,7 +220,7 @@ using Test
         B[1,1] = 0
         @test B != A
         A = rand(RGB{N0f8}, 3, 5)
-        ret = @test_throws ArgumentError padarray(A, Fill(0, (0,0), (0,0)))
+        ret = @test_throws ArgumentError padarray(A, Fill(7, (0,0), (0,0)))
         @test occursin("RGB", ret.value.msg)
         @test occursin("convert", ret.value.msg)
         A = bitrand(3, 5)


### PR DESCRIPTION
ColorTypes is used via ImageCore, and so was never explicitly tested for upgradability to v0.10. The old test relied on  `convert(RGB{N0f8}, 0)` throwing an error, but it doesn't anymore.