### PR TITLE
Fix tests to be agnostic to type printing

### DIFF
--- a/test/2d.jl
+++ b/test/2d.jl
@@ -332,7 +332,7 @@ end
     @test r1[4,4] == r2[4,4]
     @test r1[1,1] != r2[1,1]
 
-    err = ArgumentError("Fill{$Int,1}(0, (3,), (3,)) lacks the proper padding sizes for an array with 2 dimensions")
+    err = ArgumentError("$(typestring(Fill{Int,1}))(0, (3,), (3,)) lacks the proper padding sizes for an array with 2 dimensions")
     kern = Kernel.gaussian((1,1),(3,3))
     @test_throws err imfilter(A, kern, Fill(0, (3,)))
     kernf = ImageFiltering.factorkernel(kern)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,12 @@ aif = detect_ambiguities(ImageFiltering, Kernel, KernelFactors, Base)
 asa = detect_ambiguities(StaticArrays, Base)
 @test isempty(setdiff(aif, asa))
 
+function typestring(::Type{T}) where T   # from https://github.com/JuliaImages/ImageCore.jl/pull/133
+    buf = IOBuffer()
+    show(buf, T)
+    String(take!(buf))
+end
+
 include("border.jl")
 include("nd.jl")
 include("2d.jl")


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/37085 changed how type parameters
are printed, causing the following error:

```
Borders (issue #85): Test Failed at /home/runner/work/ImageFiltering.jl/ImageFiltering.jl/test/2d.jl:337
  Expression: imfilter(A, kern, Fill(0, (3,)))
    Expected: ArgumentError("Fill{Int64,1}(0, (3,), (3,)) lacks the proper padding sizes for an array with 2 dimensions")
      Thrown: ArgumentError("Fill{Int64, 1}(0, (3,), (3,)) lacks the proper padding sizes for an array with 2 dimensions")
```

See https://github.com/JuliaImages/ImageFiltering.jl/runs/1053929388?check_suite_focus=true#step:5:273 for the CI failure.