### PR TITLE
conditionally trigger benchmarkCI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,24 +2,21 @@ name: Run benchmarks
 
 on:
   pull_request:
+    types: [labeled, opened, synchronize, reopened]
 
+# Only trigger the benchmark job when you add `run benchmark` label to the PR
 jobs:
   Benchmark:
     runs-on: ubuntu-latest
-    env:
-      JULIA_DEBUG: BenchmarkCI
+    if: contains(github.event.pull_request.labels.*.name, 'run benchmark')
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
-        with:
-          version: 1.3
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
       - name: Run benchmarks
         run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
-      - name: Show
-        run: julia -e 'using BenchmarkCI; BenchmarkCI.displayjudgement()'
       - name: Post results
-        run: julia -e "using BenchmarkCI; BenchmarkCI.postjudge()"
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In this way, benchmark CI is only triggered with `run benchmark` label.