### PR TITLE
Add some precompiles

### DIFF
--- a/precompile/script.jl
+++ b/precompile/script.jl
@@ -1,0 +1,54 @@
+# This is to be used with `@snoopi_deep` from SnoopCompile
+
+using SnoopCompile
+using ImageCore
+using Statistics
+
+images2d = [rand(Float32, 100, 100),
+            rand(Float64, 100, 100),
+            rand(Gray{N0f8}, 100, 100),
+            rand(Gray{N0f16}, 100, 100),
+            rand(RGB{N0f8}, 100, 100),
+]
+
+images3d = [rand(Gray{N0f16}, 100, 100, 10),
+]
+
+tinf = @snoopi_deep begin
+    using ImageFiltering
+
+    Kernel.gaussian((3,3))
+    Kernel.gaussian((3.0,3.0))
+    Kernel.DoG(3)
+    Kernel.DoG(3.0)
+    Kernel.Laplacian()
+    Kernel.LoG(3)
+    Kernel.LoG(3.0)
+    Kernel.sobel()
+
+    KernelFactors.gaussian((3,3))
+    KernelFactors.gaussian((3.0,3.0))
+    KernelFactors.IIRGaussian((3,3))
+    KernelFactors.IIRGaussian(3.0)
+    KernelFactors.sobel()
+
+    for img in images2d
+        for kern in (Kernel.gaussian((3,3)),
+                     KernelFactors.gaussian((3,3)),
+                     KernelFactors.IIRGaussian((3.0, 3.0)))
+            imfilter(img, kern)
+        end
+        if eltype(img) <: Union{Number,Gray}
+            mapwindow(extrema, img, (3,3))
+            mapwindow(median!, img, (3,3))
+        end
+    end
+
+    for img in images3d
+        for kern in (Kernel.gaussian((3,3,3)),
+                     KernelFactors.gaussian((3,3,3)),
+                     KernelFactors.IIRGaussian((3.0, 3.0, 3.0)))
+            imfilter(img, kern)
+        end
+    end
+end

--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -102,4 +102,8 @@ function __init__()
     end
 end
 
+if Base.VERSION >= v"1.4.2"
+    include("precompile.jl")
+end
+
 end # module

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -484,4 +484,14 @@ end
 
 reflectind(r::AbstractUnitRange) = -last(r):-first(r)
 
+if Base.VERSION >= v"1.4.2" && ccall(:jl_generating_output, Cint, ()) == 1
+    precompile(Laplacian, ())
+    precompile(sobel, ())
+    for T in (Int, Float64, Float32)
+        precompile(gaussian, (Tuple{T,T},))
+        precompile(DoG, (T,))
+        precompile(LoG, (T,))
+    end
+end
+
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,37 @@
+if ccall(:jl_generating_output, Cint, ()) == 1
+    let
+        images2d = [rand(Float32, 100, 100),
+                    rand(Float64, 100, 100),
+                    rand(Gray{N0f8}, 100, 100),
+                    rand(Gray{N0f16}, 100, 100),
+                    rand(RGB{N0f8}, 100, 100),
+        ]
+        images3d = [rand(Gray{N0f16}, 100, 100, 10),
+        ]
+
+        for img in images2d
+            for kern in (Kernel.gaussian((3,3)),
+                        KernelFactors.gaussian((3,3)),
+                        KernelFactors.IIRGaussian((3.0, 3.0)))
+                for r in (CPU1(FIR()), CPUThreads(FIRTiled((5,5))), CPU1(FFT()))
+                    @assert precompile(imfilter, (typeof(r), typeof(img), typeof(kern)))
+                end
+                @assert precompile(imfilter, (typeof(img), typeof(kern)))
+            end
+            if eltype(img) <: Union{Number,Gray}
+                @assert precompile(mapwindow, (typeof(extrema), typeof(img), typeof((3,3))))
+                @assert precompile(mapwindow, (typeof(median!), typeof(img), typeof((3,3))))
+            end
+        end
+        for img in images3d
+            for kern in (Kernel.gaussian((3,3,3)),
+                         KernelFactors.gaussian((3,3,3)),
+                         KernelFactors.IIRGaussian((3.0, 3.0, 3.0)))
+                for r in (CPU1(FIR()), CPUThreads(FIRTiled((5,5))), CPU1(FFT()))
+                    @assert precompile(imfilter, (typeof(r), typeof(img), typeof(kern)))
+                end
+                @assert precompile(imfilter, (typeof(img), typeof(kern)))
+            end
+        end
+    end
+end


### PR DESCRIPTION
On the current release, the first call looks like this:
```julia
julia> @time imfilter(img, KernelFactors.gaussian((3,3)));
  2.135609 seconds (3.46 M allocations: 211.109 MiB, 12.01% gc time, 94.98% compilation time)

julia> @time mapwindow(extrema, img, (3,3))
  0.756083 seconds (1.17 M allocations: 68.258 MiB, 6.57% gc time, 99.89% compilation time)
```

On this branch, it looks like this:
```julia
julia> @time imfilter(img, KernelFactors.gaussian((3,3)));
  0.620004 seconds (362.78 k allocations: 40.455 MiB, 1.47% gc time, 96.09% compilation time)

julia> @time mapwindow(extrema, img, (3,3))
  0.385470 seconds (334.52 k allocations: 19.585 MiB, 9.43% gc time, 99.82% compilation time)
```

Quite a nice reduction in latency.

I should note this requires https://github.com/JuliaMath/AbstractFFTs.jl/pull/48 and also some changes to FFTW.jl that I haven't yet submitted since they rely on the changes in AbstractFFTs.