### PR TITLE
disable docs push preview

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,5 +23,6 @@ demos_cb()
 
 deploydocs(
     repo   = "github.com/JuliaImages/ImageFiltering.jl.git",
-    push_preview = true
+    # NOTE: remove the comment if the PR requires a push preview
+    # push_preview = true
 )


### PR DESCRIPTION
It's not very helpful to push preview for every PR; it occupies a lot of storage and makes normal clones slower (unless the users explicitly clone one specific branch). For this reason, I've commented it out. Anyone with write-permission that wants a docs preview can temporarily remove the comment to enable it.