### PR TITLE
Add `box` and `laplacian2d`

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -37,6 +37,14 @@ function product2d(kf)
 end
 
 """
+    kern = box(m, n)
+    kern = box((m, n, ...))
+
+Return a box kernel computing a moving average. `m, n, ...` specify the size of the kernel, which is centered around zero.
+"""
+box(sz::Dims) = broadcast(*, KernelFactors.box(sz)...)
+
+"""
 ```julia
     diff1, diff2 = sobel()
 ```
@@ -380,6 +388,40 @@ function Base.convert(::Type{AbstractArray}, L::Laplacian{N}) where N
 end
 _reshape(L::Laplacian{N}, ::Val{N}) where {N} = L
 
+"""
+    laplacian2d(alpha::Number)
+
+Construct a weighted discrete Laplacian approximation in 2d. `alpha` controls the weighting of the faces
+relative to the corners.
+
+# Examples
+
+```jldoctest
+julia> Kernel.laplacian2d(0)      # the standard Laplacian
+3×3 OffsetArray(::Matrix{Float64}, -1:1, -1:1) with eltype Float64 with indices -1:1×-1:1:
+ 0.0   1.0  0.0
+ 1.0  -4.0  1.0
+ 0.0   1.0  0.0
+
+julia> Kernel.laplacian2d(1)      # a corner-focused Laplacian
+3×3 OffsetArray(::Matrix{Float64}, -1:1, -1:1) with eltype Float64 with indices -1:1×-1:1:
+ 0.5   0.0  0.5
+ 0.0  -2.0  0.0
+ 0.5   0.0  0.5
+
+julia> Kernel.laplacian2d(0.5)    # equal weight for face-pixels and corner-pixels.
+3×3 OffsetArray(::Matrix{Float64}, -1:1, -1:1) with eltype Float64 with indices -1:1×-1:1:
+ 0.333333   0.333333  0.333333
+ 0.333333  -2.66667   0.333333
+ 0.333333   0.333333  0.333333
+```
+"""
+function laplacian2d(alpha::Number=0)
+    lc = alpha/(1 + alpha)
+    lb = (1 - alpha)/(1 + alpha)
+    lm = -4/(1 + alpha)
+    return centered([lc lb lc; lb lm lb; lc lb lc])
+end
 
 """
     gabor(size_x,size_y,σ,θ,λ,γ,ψ) -> (k_real,k_complex)

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -37,12 +37,13 @@ function product2d(kf)
 end
 
 """
-    kern = box(m, n)
     kern = box((m, n, ...))
 
 Return a box kernel computing a moving average. `m, n, ...` specify the size of the kernel, which is centered around zero.
 """
 box(sz::Dims) = broadcast(*, KernelFactors.box(sz)...)
+# We don't support box(m::Int...) mostly because of `gaussian(σ::Real) = gaussian((σ, σ))` defaulting to
+# isotropic 2d rather than a 1d Gaussian.
 
 """
 ```julia

--- a/src/kernelfactors.jl
+++ b/src/kernelfactors.jl
@@ -3,6 +3,7 @@
 each stored in terms of their factors. The following kernels are
 supported:
 
+  - `box`
   - `sobel`
   - `prewitt`
   - `ando3`, `ando4`, and `ando5` (the latter in 2d only)
@@ -147,6 +148,18 @@ function indexsplit(I::CartesianIndex{N}, v::ReshapedOneD{<:Any,N}) where N
 end
 
 #### FIR filters
+
+"""
+    kern1, kern2 = box(m, n)
+    kerns = box((m, n, ...))
+
+Return a tuple of "flat" kernels, where, for example, `kern1[i] == 1/m` and has length `m`.
+"""
+function box(sz::Dims)
+    all(isodd, sz) || throw(ArgumentError("kernel dimensions must be odd, got $sz"))
+    return kernelfactors(ntuple(d -> centered([1/sz[d] for i=1:sz[d]]), length(sz)))
+end
+box(sz::Int...) = box(sz)
 
 ## gradients
 

--- a/test/specialty.jl
+++ b/test/specialty.jl
@@ -150,6 +150,17 @@ using ImageFiltering: IdentityUnitRange
                              z z z z edgecoef*c]
             end
         end
+        # The doctests seem adequate for laplacian2d
+    end
+
+    @testset "box" begin
+        @test KernelFactors.box(3) == (centered([1/3, 1/3, 1/3]),)
+        @test KernelFactors.box(3, 5) == (centered(reshape([1/3, 1/3, 1/3], 3, 1)), centered([1/5, 1/5, 1/5, 1/5, 1/5]'))
+        @test KernelFactors.box((3,5,7)) == KernelFactors.box(3, 5, 7)
+        @test Kernel.box((3,)) == centered([1/3, 1/3, 1/3])
+        @test Kernel.box((3, 5)) == centered([1/3, 1/3, 1/3] .* [1/5, 1/5, 1/5, 1/5, 1/5]')
+        @test_throws ArgumentError KernelFactors.box((3, 4, 5))
+        @test_throws ArgumentError Kernel.box((3, 4, 5))
     end
 
     @testset "gaussian" begin

--- a/test/specialty.jl
+++ b/test/specialty.jl
@@ -150,7 +150,9 @@ using ImageFiltering: IdentityUnitRange
                              z z z z edgecoef*c]
             end
         end
-        # The doctests seem adequate for laplacian2d
+        @test Kernel.laplacian2d(0.5) ≈ centered([ 1/3  1/3  1/3;
+                                                   1/3 -8/3  1/3;
+                                                   1/3  1/3  1/3])
     end
 
     @testset "box" begin


### PR DESCRIPTION
These come from Images.jl and are part of moving most/all code
out to make it a meta-package.

As annotated in https://github.com/JuliaImages/Images.jl/pull/971, these may be the last of the moves here (`gaussian_pyramid` does not seem likely to move). Consequently, once this merges we could release a new version, unblocking https://github.com/JuliaImages/ImageSegmentation.jl/pull/72, or we could wait for #214 and/or #225.