### PR TITLE
Reexport FFTW

### DIFF
--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -1,6 +1,6 @@
 module ImageFiltering
 
-using FFTW
+@reexport using FFTW
 using ImageCore, FFTViews, OffsetArrays, StaticArrays, ComputationalResources, TiledIteration
 # Where possible we avoid a direct dependency to reduce the number of [compat] bounds
 # using FixedPointNumbers: Normed, N0f8 # reexported by ImageCore


### PR DESCRIPTION
`fft`/`ifft` and related utils might be something people would want to have when they `using ImageFiltering`.

However, I don't have a strong opinion here; actually, I'm trying to be conservative on exporting too many symbols.

Thoughts?