### PR TITLE
Less alloc in TriggsSdika filtering (fix #243)

### DIFF
--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -1327,7 +1327,7 @@ _imfilter_inplace_tuple!(r, out, img, ::Tuple{}, Rbegin, inds, Rend, border) = o
     if length(ind) <= max(k, l)
         throw_imfilter_dim(Rbegin, length(ind), max(k, l))
     end
-    indleft = ind[begin:begin+k-1]
+    indleft = ind[firstindex(ind):firstindex(ind)+k-1]
     indright = ind[end-l+1:end]
     for Iend in Rend
         # Initialize the left border

--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -1312,6 +1312,12 @@ _imfilter_inplace_tuple!(r, out, img, ::Tuple{}, Rbegin, inds, Rend, border) = o
                                   out, img, kernel::TriggsSdika{T,k,l},
                                   Rbegin::CartesianIndices, ind::AbstractUnitRange,
                                   Rend::CartesianIndices, border::AbstractBorder) where {T,k,l}
+
+    @noinline function throw_imfilter_dim(R, n, l)
+        dim = ndims(R)+1
+        throw(DimensionMismatch("size $n of img along dimension $dim is too small for filtering with IIR kernel of length $l"))
+    end
+
     if iscopy(kernel)
         if !(out === img)
             copyto!(out, img)
@@ -1319,12 +1325,12 @@ _imfilter_inplace_tuple!(r, out, img, ::Tuple{}, Rbegin, inds, Rend, border) = o
         return out
     end
     if length(ind) <= max(k, l)
-        dim = ndims(Rbegin)+1
-        throw(DimensionMismatch("size of img along dimension $dim $(length(ind)) is too small for filtering with IIR kernel of length $(max(k,l))"))
+        throw_imfilter_dim(Rbegin, length(ind), max(k, l))
     end
+    indleft = ind[begin:begin+k-1]
+    indright = ind[end-l+1:end]
     for Iend in Rend
         # Initialize the left border
-        indleft = collect(Iterators.take(ind,k))
         for Ibegin in Rbegin
             leftborder!(out, img, kernel, Ibegin, indleft, Iend, border)
         end
@@ -1341,7 +1347,6 @@ _imfilter_inplace_tuple!(r, out, img, ::Tuple{}, Rbegin, inds, Rend, border) = o
             end
         end
         # Initialize the right border
-        indright = ind[end-l+1:end]
         for Ibegin in Rbegin
             rightborder!(out, img, kernel, Ibegin, indright, Iend, border)
         end


### PR DESCRIPTION
Putting the string interpolation behind a `@noinline` is the key change,
but it doesn't hurt to hoist the range creation.

Of the few remaining allocations, about half will be fixed by
https://github.com/JuliaLang/julia/pull/43990, as they are another
instance of https://github.com/JuliaLang/julia/issues/35972