### PR TITLE
correct docstrings on kernel.gaussian syntax

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -259,7 +259,7 @@ bickley() = product2d(KernelFactors.bickley())
 bickley(extended, d) = (broadcast(*, KernelFactors.bickley(extended, d)...),)
 
 """
-    gaussian((σ1, σ2, ...), [(l1, l2, ...)]) -> g
+    gaussian((σ1, σ2, ...), (l1, l2, ...)) -> g
     gaussian(σ)                  -> g
 
 Construct a multidimensional gaussian filter, with standard deviation


### PR DESCRIPTION
Remove brackets in docstring for kernel length, as it requires a tuple and not a array.