### PR TITLE
WIP: tweak LoG kernel value

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -334,7 +334,9 @@ function LoG(σs::NTuple{N}) where N
         xσ = x.^2 ./ σ2
         (sum(xσ./σ2) - σ2i) * exp(-sum(xσ)/2)
     end
-    [C*df(I, σ2, σ2i) for I in R]
+    h = [C*df(I, σ2, σ2i) for I in R]
+    # make the kernel sum to zero
+    return h .- sum(h)/length(h)
 end
 LoG(σ::Real) = LoG((σ,σ))
 


### PR DESCRIPTION
We would expect laplacian kernel sum to zero, while the current implementation doesn't meet this:

```julia
julia> h = ImageFiltering.Kernel.LoG((0.5, 0.5))
5×5 OffsetArray(::Matrix{Float64}, -2:2, -2:2) with eltype Float64 with indices -2:2×-2:2:
 8.59705e-6  0.00208098   0.0119595  0.00208098  8.59705e-6
 0.00208098  0.279842     0.689257   0.279842    0.00208098
 0.0119595   0.689257    -5.09296    0.689257    0.0119595
 0.00208098  0.279842     0.689257   0.279842    0.00208098
 8.59705e-6  0.00208098   0.0119595  0.00208098  8.59705e-6

julia> sum(h)
-1.1520408898110324
```

This PR tries to fix it.

TODO:

- [ ] check the test
- [ ] allow custom size input `ImageFiltering.Kernel.LoG((0.5, 0.5), (5, 5))`