### PR TITLE
Add warning to imfilter! for transposed OffsetVectors

### DIFF
--- a/src/imfilter.jl
+++ b/src/imfilter.jl
@@ -227,6 +227,10 @@ end
 
 # Step 5: if necessary, pick an algorithm
 function imfilter!(out::AbstractArray, img::AbstractArray, kernel::ProcessedKernel, border::AbstractBorder)
+    if any(x -> (isa(x, Adjoint) || isa(x, Transpose)) && isa(x.parent, OffsetVector) && first(OffsetArrays.center(x.parent)) != 1, kernel)
+        @warn "A transposed OffsetVector automatically has an index of 1 in the first dimension. \
+            Consider using an OffsetMatrix to control the index of each dimension."
+    end
     imfilter!(out, img, kernel, border, filter_algorithm(out, img, kernel))
 end
 


### PR DESCRIPTION
Fixes #269 by providing a warning when a transpose of an OffsetVector is passed in as a kernel component.

It seems any proper attempt to fix this is far too complicated, if even possible in the near term. At least a warning should direct people to the better way.