### PR TITLE
Cut allocations in `padindex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageFiltering"
 uuid = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 author = ["Tim Holy <tim.holy@gmail.com>", "Jan Weidner <jw3126@gmail.com>"]
-version = "0.7.10"
+version = "0.7.11"
 
 [deps]
 CatIndices = "aafaddc9-749c-510e-ac4f-586e18779b91"

--- a/src/border.jl
+++ b/src/border.jl
@@ -564,23 +564,23 @@ Generate an index-vector to be used for padding. `inds` specifies the image axes
 function padindex(border::Pad, lo::Int, inds::UnitRange{Int}, hi::Int)
     if border.style == :replicate
         indsnew = Vector{Int}(undef, length(inds) + lo + hi)
-		indsnew[1:lo] .= first(inds)
-		indsnew[lo .+ eachindex(inds)] .= inds
-		indsnew[lo + length(inds) + 1:end] .= last(inds)
+        indsnew[1:lo] .= first(inds)
+        indsnew[lo .+ eachindex(inds)] .= inds
+        indsnew[lo + length(inds) + 1:end] .= last(inds)
         OffsetArray(indsnew, first(inds)-lo:last(inds)+hi)
     elseif border.style == :circular
         return modrange(extend(lo, inds, hi), inds)
     elseif border.style == :symmetric
         indsnew = Vector{Int}(undef, 2length(inds))
-		indsnew[eachindex(inds)] .= inds
-		indsnew[end:-1:length(inds) + 1] .= inds
+        indsnew[eachindex(inds)] .= inds
+        indsnew[end:-1:length(inds) + 1] .= inds
         I = OffsetArray(indsnew, (0:2*length(inds)-1) .+ first(inds))
         r = modrange(extend(lo, inds, hi), axes(I, 1))
         return I[r]
     elseif border.style == :reflect
-        indsnew = Vector{Int}(undef, 2length(inds))
-		indsnew[eachindex(inds)] .= inds
-		indsnew[length(inds) + 1:end] .= last(inds)-1:-1:first(inds)+1
+        indsnew = Vector{Int}(undef, 2length(inds) - 2)
+        indsnew[eachindex(inds)] .= inds
+        indsnew[length(inds) + 1:end] .= last(inds)-1:-1:first(inds)+1
         I = OffsetArray(indsnew, (0:2*length(inds)-3) .+ first(inds))
         return I[modrange(extend(lo, inds, hi), axes(I, 1))]
     else

--- a/src/border.jl
+++ b/src/border.jl
@@ -563,16 +563,25 @@ Generate an index-vector to be used for padding. `inds` specifies the image axes
 """
 function padindex(border::Pad, lo::Int, inds::UnitRange{Int}, hi::Int)
     if border.style == :replicate
-        indsnew = Int[fill(first(inds), lo); inds; fill(last(inds), hi)]
+        indsnew = Vector{Int}(undef, length(inds) + lo + hi)
+		indsnew[1:lo] .= first(inds)
+		indsnew[lo .+ eachindex(inds)] .= inds
+		indsnew[lo + length(inds) + 1:end] .= last(inds)
         OffsetArray(indsnew, first(inds)-lo:last(inds)+hi)
     elseif border.style == :circular
         return modrange(extend(lo, inds, hi), inds)
     elseif border.style == :symmetric
-        I = OffsetArray(Int[inds; reverse(inds)], (0:2*length(inds)-1) .+ first(inds))
+        indsnew = Vector{Int}(undef, 2length(inds))
+		indsnew[eachindex(inds)] .= inds
+		indsnew[end:-1:length(inds) + 1] .= inds
+        I = OffsetArray(indsnew, (0:2*length(inds)-1) .+ first(inds))
         r = modrange(extend(lo, inds, hi), axes(I, 1))
         return I[r]
     elseif border.style == :reflect
-        I = OffsetArray(Int[inds; last(inds)-1:-1:first(inds)+1], (0:2*length(inds)-3) .+ first(inds))
+        indsnew = Vector{Int}(undef, 2length(inds))
+		indsnew[eachindex(inds)] .= inds
+		indsnew[length(inds) + 1:end] .= last(inds)-1:-1:first(inds)+1
+        I = OffsetArray(indsnew, (0:2*length(inds)-3) .+ first(inds))
         return I[modrange(extend(lo, inds, hi), axes(I, 1))]
     else
         error("border style $(border.style) unrecognized")

--- a/src/border.jl
+++ b/src/border.jl
@@ -563,7 +563,7 @@ Generate an index-vector to be used for padding. `inds` specifies the image axes
 """
 function padindex(border::Pad, lo::Int, inds::UnitRange{Int}, hi::Int)
     if border.style == :replicate
-        indsnew = OffsetArray{Int}(undef, length(inds) + lo + hi, first(inds)-lo:last(inds)+hi)
+        indsnew = OffsetArray{Int}(undef, first(inds)-lo:last(inds)+hi)
         offview = OffsetArrays.no_offset_view(indsnew)
         offview[1:lo] .= first(inds)
         offview[lo .+ eachindex(inds)] .= inds

--- a/src/border.jl
+++ b/src/border.jl
@@ -579,7 +579,7 @@ function padindex(border::Pad, lo::Int, inds::UnitRange{Int}, hi::Int)
         r = modrange(extend(lo, inds, hi), axes(I, 1))
         return I[r]
     elseif border.style == :reflect
-        I = OffsetArray(undef, (0:2*length(inds)-3) .+ first(inds))
+        I = OffsetArray{Int}(undef, (0:2*length(inds)-3) .+ first(inds))
         offview = OffsetArrays.no_offset_view(I)
         offview[eachindex(inds)] .= inds
         offview[length(inds) + 1:end] .= last(inds)-1:-1:first(inds)+1

--- a/src/border.jl
+++ b/src/border.jl
@@ -564,7 +564,7 @@ Generate an index-vector to be used for padding. `inds` specifies the image axes
 function padindex(border::Pad, lo::Int, inds::UnitRange{Int}, hi::Int)
     if border.style == :replicate
         indsnew = OffsetArray{Int}(undef, length(inds) + lo + hi, first(inds)-lo:last(inds)+hi)
-        offview = OffsetArrays.no_offset_view(AO)
+        offview = OffsetArrays.no_offset_view(indsnew)
         offview[1:lo] .= first(inds)
         offview[lo .+ eachindex(inds)] .= inds
         offview[lo + length(inds) + 1:end] .= last(inds)


### PR DESCRIPTION
`padindex` results in a large number of allocations due to multiple array creations and concatenations. This PR only creates a single array and values are copied into it.