### PR TITLE
Fix warnings for Julia 1.12

### DIFF
--- a/src/ImageFiltering.jl
+++ b/src/ImageFiltering.jl
@@ -65,7 +65,7 @@ module Algorithm
 end
 using .Algorithm: Alg, FFT, FIR, FIRTiled, IIR, Mixed
 
-Alg(r::AbstractResource{A}) where {A<:Alg} = r.settings
+Algorithm.Alg(r::AbstractResource{A}) where {A<:Alg} = r.settings
 
 include("utils.jl")
 include("compat.jl")


### PR DESCRIPTION
Not sure if this is the right way to fix this - the warning goes away but lots of test failures in 1.12. I think this PR should be ok to merge so long as it passes on 1.11.

1.12 test failures will need separate investigation, which is not related to this PR.